### PR TITLE
Use relative asset paths for GitHub Pages

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -8,34 +8,34 @@
   <meta property="og:title" content="Contacto · Retro Web" />
   <meta property="og:description" content="Escríbeme para colaborar en proyectos retro" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="/assets/img/og-banner.png" />
+  <meta property="og:image" content="./assets/img/og-banner.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="alternate icon" href="/assets/img/favicon.png" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="./assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="alternate icon" href="./assets/img/favicon.png" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
 </head>
 
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="./"><img class="brand-logo" src="./assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="./">Inicio</a>
+      <a href="./sobre.html">Sobre mí</a>
+      <a href="./portafolio.html">Portafolio</a>
+      <a href="./contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="./">Inicio</a>
+    <a href="./sobre.html">Sobre mí</a>
+    <a href="./portafolio.html">Portafolio</a>
+    <a href="./contacto.html">Contacto</a>
   </nav>
 </header>
 
@@ -59,6 +59,6 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="./assets/js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,34 +8,34 @@
   <meta property="og:title" content="Inicio · Retro Web" />
   <meta property="og:description" content="Portafolio artístico con toques retro" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="/assets/img/og-banner.png" />
+  <meta property="og:image" content="./assets/img/og-banner.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="alternate icon" href="/assets/img/favicon.png" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="./assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="alternate icon" href="./assets/img/favicon.png" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
 </head>
 
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="./"><img class="brand-logo" src="./assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="./">Inicio</a>
+      <a href="./sobre.html">Sobre mí</a>
+      <a href="./portafolio.html">Portafolio</a>
+      <a href="./contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="./">Inicio</a>
+    <a href="./sobre.html">Sobre mí</a>
+    <a href="./portafolio.html">Portafolio</a>
+    <a href="./contacto.html">Contacto</a>
   </nav>
 </header>
 
@@ -43,7 +43,7 @@
   <section class="hero">
     <h1 class="glow">Retro Web</h1>
     <p class="subtitle">Homenaje artístico al arcade de los 80</p>
-    <a class="btn cta" href="/portafolio.html">Ver Portafolio ochentañero</a>
+    <a class="btn cta" href="./portafolio.html">Ver Portafolio ochentañero</a>
 
     <div class="crt">
       <canvas id="heroCanvas" width="640" height="360" aria-label="Animación retro"></canvas>
@@ -68,6 +68,6 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="./assets/js/script.js"></script>
 </body>
 </html>

--- a/portafolio.html
+++ b/portafolio.html
@@ -8,34 +8,34 @@
   <meta property="og:title" content="Portafolio · Retro Web" />
   <meta property="og:description" content="Seis proyectos p5.js inspirados en arcades míticos" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="/assets/img/og-banner.png" />
+  <meta property="og:image" content="./assets/img/og-banner.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="alternate icon" href="/assets/img/favicon.png" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="./assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="alternate icon" href="./assets/img/favicon.png" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
 </head>
 
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="./"><img class="brand-logo" src="./assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="./">Inicio</a>
+      <a href="./sobre.html">Sobre mí</a>
+      <a href="./portafolio.html">Portafolio</a>
+      <a href="./contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="./">Inicio</a>
+    <a href="./sobre.html">Sobre mí</a>
+    <a href="./portafolio.html">Portafolio</a>
+    <a href="./contacto.html">Contacto</a>
   </nav>
 </header>
 
@@ -46,32 +46,32 @@
 <article class="project">
   <h3>Space Invaders Recharged</h3>
   <p>Los marcianitos nunca pasan de moda, pero ahora disparan con ritmo ochentañero.</p>
-  <a class="btn" href="/proyectos/space-invaders/">Abrir demo</a>
+  <a class="btn" href="./proyectos/space-invaders/">Abrir demo</a>
 </article>
 <article class="project">
   <h3>Pac-Man Remix</h3>
   <p>El laberinto sigue ahí, pero los fantasmas ahora bailan synthwave.</p>
-  <a class="btn" href="/proyectos/pacman/">Abrir demo</a>
+  <a class="btn" href="./proyectos/pacman/">Abrir demo</a>
 </article>
 <article class="project">
   <h3>Donkey Kong Rampage</h3>
   <p>De la obra al pixel: saltar, trepar y esquivar barriles retro con alma española.</p>
-  <a class="btn" href="/proyectos/donkey-kong/">Abrir demo</a>
+  <a class="btn" href="./proyectos/donkey-kong/">Abrir demo</a>
 </article>
 <article class="project">
   <h3>Galaga Reloaded</h3>
   <p>Defiende la galaxia desde tu recreativa favorita, ahora con neones fosforitos.</p>
-  <a class="btn" href="/proyectos/galaga/">Abrir demo</a>
+  <a class="btn" href="./proyectos/galaga/">Abrir demo</a>
 </article>
 <article class="project">
   <h3>Ghosts’n Goblins Revival</h3>
   <p>Sir Arthur vuelve, en calzoncillos pixelados, a enfrentarse a demonios imposibles.</p>
-  <a class="btn" href="/proyectos/ghosts-goblins/">Abrir demo</a>
+  <a class="btn" href="./proyectos/ghosts-goblins/">Abrir demo</a>
 </article>
 <article class="project">
   <h3>Out Run Neo80</h3>
   <p>Coge el Ferrari, pisa a fondo y recorre carreteras llenas de sol, palmeras y nostalgia.</p>
-  <a class="btn" href="/proyectos/outrun/">Abrir demo</a>
+  <a class="btn" href="./proyectos/outrun/">Abrir demo</a>
 </article>
   </div>
 </main>
@@ -84,6 +84,6 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="./assets/js/script.js"></script>
 </body>
 </html>

--- a/proyectos/donkey-kong/index.html
+++ b/proyectos/donkey-kong/index.html
@@ -6,8 +6,8 @@
   <title>Donkey Kong Rampage · Retro Web</title>
   <meta name="description" content="De la obra al pixel: saltar, trepar y esquivar barriles retro con alma española." />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="../../assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../assets/css/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
   <style>
     main .canvas-wrap{border:1px solid var(--border);padding:8px;background:rgba(255,255,255,0.02)}
@@ -16,27 +16,27 @@
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="../../index.html"><img class="brand-logo" src="../../assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="../../index.html">Inicio</a>
+      <a href="../../sobre.html">Sobre mí</a>
+      <a href="../../portafolio.html">Portafolio</a>
+      <a href="../../contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="../../index.html">Inicio</a>
+    <a href="../../sobre.html">Sobre mí</a>
+    <a href="../../portafolio.html">Portafolio</a>
+    <a href="../../contacto.html">Contacto</a>
   </nav>
 </header>
 
 <main class="container page">
-  <a class="btn" href="/portafolio.html">← Volver al portafolio</a>
+  <a class="btn" href="../../portafolio.html">← Volver al portafolio</a>
   <h1>Donkey Kong Rampage</h1>
   <p class="lead">De la obra al pixel: saltar, trepar y esquivar barriles retro con alma española.</p>
   <div class="canvas-wrap" id="canvas-wrap"></div>
@@ -50,7 +50,7 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="../../assets/js/script.js"></script>
 </body>
 </html>
 

--- a/proyectos/galaga/index.html
+++ b/proyectos/galaga/index.html
@@ -6,8 +6,8 @@
   <title>Galaga Reloaded · Retro Web</title>
   <meta name="description" content="Defiende la galaxia desde tu recreativa favorita, ahora con neones fosforitos." />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="../../assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../assets/css/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
   <style>
     main .canvas-wrap{border:1px solid var(--border);padding:8px;background:rgba(255,255,255,0.02)}
@@ -16,27 +16,27 @@
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="../../index.html"><img class="brand-logo" src="../../assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="../../index.html">Inicio</a>
+      <a href="../../sobre.html">Sobre mí</a>
+      <a href="../../portafolio.html">Portafolio</a>
+      <a href="../../contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="../../index.html">Inicio</a>
+    <a href="../../sobre.html">Sobre mí</a>
+    <a href="../../portafolio.html">Portafolio</a>
+    <a href="../../contacto.html">Contacto</a>
   </nav>
 </header>
 
 <main class="container page">
-  <a class="btn" href="/portafolio.html">← Volver al portafolio</a>
+  <a class="btn" href="../../portafolio.html">← Volver al portafolio</a>
   <h1>Galaga Reloaded</h1>
   <p class="lead">Defiende la galaxia desde tu recreativa favorita, ahora con neones fosforitos.</p>
   <div class="canvas-wrap" id="canvas-wrap"></div>
@@ -50,7 +50,7 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="../../assets/js/script.js"></script>
 </body>
 </html>
 

--- a/proyectos/ghosts-goblins/index.html
+++ b/proyectos/ghosts-goblins/index.html
@@ -6,8 +6,8 @@
   <title>Ghosts’n Goblins Revival · Retro Web</title>
   <meta name="description" content="Sir Arthur vuelve, en calzoncillos pixelados, a enfrentarse a demonios imposibles." />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="../../assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../assets/css/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
   <style>
     main .canvas-wrap{border:1px solid var(--border);padding:8px;background:rgba(255,255,255,0.02)}
@@ -16,27 +16,27 @@
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="../../index.html"><img class="brand-logo" src="../../assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="../../index.html">Inicio</a>
+      <a href="../../sobre.html">Sobre mí</a>
+      <a href="../../portafolio.html">Portafolio</a>
+      <a href="../../contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="../../index.html">Inicio</a>
+    <a href="../../sobre.html">Sobre mí</a>
+    <a href="../../portafolio.html">Portafolio</a>
+    <a href="../../contacto.html">Contacto</a>
   </nav>
 </header>
 
 <main class="container page">
-  <a class="btn" href="/portafolio.html">← Volver al portafolio</a>
+  <a class="btn" href="../../portafolio.html">← Volver al portafolio</a>
   <h1>Ghosts’n Goblins Revival</h1>
   <p class="lead">Sir Arthur vuelve, en calzoncillos pixelados, a enfrentarse a demonios imposibles.</p>
   <div class="canvas-wrap" id="canvas-wrap"></div>
@@ -50,7 +50,7 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="../../assets/js/script.js"></script>
 </body>
 </html>
 

--- a/proyectos/outrun/index.html
+++ b/proyectos/outrun/index.html
@@ -6,8 +6,8 @@
   <title>Out Run Neo80 · Retro Web</title>
   <meta name="description" content="Coge el Ferrari, pisa a fondo y recorre carreteras llenas de sol, palmeras y nostalgia." />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="../../assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../assets/css/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
   <style>
     main .canvas-wrap{border:1px solid var(--border);padding:8px;background:rgba(255,255,255,0.02)}
@@ -16,27 +16,27 @@
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="../../index.html"><img class="brand-logo" src="../../assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="../../index.html">Inicio</a>
+      <a href="../../sobre.html">Sobre mí</a>
+      <a href="../../portafolio.html">Portafolio</a>
+      <a href="../../contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="../../index.html">Inicio</a>
+    <a href="../../sobre.html">Sobre mí</a>
+    <a href="../../portafolio.html">Portafolio</a>
+    <a href="../../contacto.html">Contacto</a>
   </nav>
 </header>
 
 <main class="container page">
-  <a class="btn" href="/portafolio.html">← Volver al portafolio</a>
+  <a class="btn" href="../../portafolio.html">← Volver al portafolio</a>
   <h1>Out Run Neo80</h1>
   <p class="lead">Coge el Ferrari, pisa a fondo y recorre carreteras llenas de sol, palmeras y nostalgia.</p>
   <div class="canvas-wrap" id="canvas-wrap"></div>
@@ -50,7 +50,7 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="../../assets/js/script.js"></script>
 </body>
 </html>
 

--- a/proyectos/pacman/index.html
+++ b/proyectos/pacman/index.html
@@ -6,8 +6,8 @@
   <title>Pac-Man Remix · Retro Web</title>
   <meta name="description" content="El laberinto sigue ahí, pero los fantasmas ahora bailan synthwave." />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="../../assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../assets/css/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
   <style>
     main .canvas-wrap{border:1px solid var(--border);padding:8px;background:rgba(255,255,255,0.02)}
@@ -16,27 +16,27 @@
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="../../index.html"><img class="brand-logo" src="../../assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="../../index.html">Inicio</a>
+      <a href="../../sobre.html">Sobre mí</a>
+      <a href="../../portafolio.html">Portafolio</a>
+      <a href="../../contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="../../index.html">Inicio</a>
+    <a href="../../sobre.html">Sobre mí</a>
+    <a href="../../portafolio.html">Portafolio</a>
+    <a href="../../contacto.html">Contacto</a>
   </nav>
 </header>
 
 <main class="container page">
-  <a class="btn" href="/portafolio.html">← Volver al portafolio</a>
+  <a class="btn" href="../../portafolio.html">← Volver al portafolio</a>
   <h1>Pac-Man Remix</h1>
   <p class="lead">El laberinto sigue ahí, pero los fantasmas ahora bailan synthwave.</p>
   <div class="canvas-wrap" id="canvas-wrap"></div>
@@ -50,7 +50,7 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="../../assets/js/script.js"></script>
 </body>
 </html>
 

--- a/proyectos/space-invaders/index.html
+++ b/proyectos/space-invaders/index.html
@@ -6,8 +6,8 @@
   <title>Space Invaders Recharged · Retro Web</title>
   <meta name="description" content="Los marcianitos nunca pasan de moda, pero ahora disparan con ritmo ochentañero." />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="../../assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="../../assets/css/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
   <style>
     main .canvas-wrap{border:1px solid var(--border);padding:8px;background:rgba(255,255,255,0.02)}
@@ -16,27 +16,27 @@
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="../../index.html"><img class="brand-logo" src="../../assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="../../index.html">Inicio</a>
+      <a href="../../sobre.html">Sobre mí</a>
+      <a href="../../portafolio.html">Portafolio</a>
+      <a href="../../contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="../../index.html">Inicio</a>
+    <a href="../../sobre.html">Sobre mí</a>
+    <a href="../../portafolio.html">Portafolio</a>
+    <a href="../../contacto.html">Contacto</a>
   </nav>
 </header>
 
 <main class="container page">
-  <a class="btn" href="/portafolio.html">← Volver al portafolio</a>
+  <a class="btn" href="../../portafolio.html">← Volver al portafolio</a>
   <h1>Space Invaders Recharged</h1>
   <p class="lead">Los marcianitos nunca pasan de moda, pero ahora disparan con ritmo ochentañero.</p>
   <div class="canvas-wrap" id="canvas-wrap"></div>
@@ -50,7 +50,7 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="../../assets/js/script.js"></script>
 </body>
 </html>
 

--- a/sobre.html
+++ b/sobre.html
@@ -8,34 +8,34 @@
   <meta property="og:title" content="Sobre mí · Retro Web" />
   <meta property="og:description" content="Conoce a Alberto y su universo arcade" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="/assets/img/og-banner.png" />
+  <meta property="og:image" content="./assets/img/og-banner.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="alternate icon" href="/assets/img/favicon.png" />
-  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="./assets/img/favicon.svg" type="image/svg+xml" />
+  <link rel="alternate icon" href="./assets/img/favicon.png" />
+  <link rel="stylesheet" href="./assets/css/styles.css" />
 </head>
 
 <body>
 <header class="navbar" id="navbar">
   <div class="container nav-inner">
-    <a class="brand" href="/"><img class="brand-logo" src="/assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
+    <a class="brand" href="./"><img class="brand-logo" src="./assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
     <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
       <span></span><span></span><span></span>
     </button>
     <nav class="nav-desktop">
-      <a href="/">Inicio</a>
-      <a href="/sobre.html">Sobre mí</a>
-      <a href="/portafolio.html">Portafolio</a>
-      <a href="/contacto.html">Contacto</a>
+      <a href="./">Inicio</a>
+      <a href="./sobre.html">Sobre mí</a>
+      <a href="./portafolio.html">Portafolio</a>
+      <a href="./contacto.html">Contacto</a>
     </nav>
   </div>
   <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="/">Inicio</a>
-    <a href="/sobre.html">Sobre mí</a>
-    <a href="/portafolio.html">Portafolio</a>
-    <a href="/contacto.html">Contacto</a>
+    <a href="./">Inicio</a>
+    <a href="./sobre.html">Sobre mí</a>
+    <a href="./portafolio.html">Portafolio</a>
+    <a href="./contacto.html">Contacto</a>
   </nav>
 </header>
 
@@ -63,6 +63,6 @@
     </div>
   </div>
 </footer>
-<script src="/assets/js/script.js"></script>
+<script src="./assets/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace absolute asset and navigation references in the main site pages with relative paths compatible with GitHub Pages
- update each project detail page to load shared assets and navigation links via relative URLs

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1072736fc832b90a6f18816ab76fc