### PR TITLE
Fix hero canvas responsive sizing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -41,6 +41,7 @@ a{color:var(--accent)}
 .hero-logo{display:grid;place-items:center;gap:6px;margin:0}
 .hero-logo img{width:180px;height:auto;image-rendering:pixelated;filter:drop-shadow(0 0 6px var(--accent))}
 .hero-logo figcaption{margin:0;font-size:.7rem;color:var(--accent2);text-shadow:0 0 6px rgba(255,255,0,0.4)}
+#heroCanvas{width:100%;max-width:640px;height:auto}
 h1,h2,h3{color:var(--primary);text-shadow:0 0 10px var(--primary)}
 .subtitle{opacity:.9}
 .btn{display:inline-block;text-decoration:none;color:#000;background:var(--accent2);padding:12px 16px;border:2px solid #000;box-shadow:4px 4px 0 #000;transition:transform .05s}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -34,8 +34,22 @@ if (hamburger && mobileMenu) {
   const cvs = document.getElementById('heroCanvas');
   if(!cvs) return;
   const ctx = cvs.getContext('2d');
+  const aspectRatio = 16 / 9;
+  function resizeCanvas(){
+    const parentWidth = cvs.parentElement ? cvs.parentElement.clientWidth : 0;
+    const availableWidth = parentWidth || cvs.clientWidth || 640;
+    const width = Math.max(1, Math.min(availableWidth, 640));
+    const height = Math.max(1, Math.round(width / aspectRatio));
+    if(cvs.width !== width || cvs.height !== height){
+      cvs.width = width;
+      cvs.height = height;
+    }
+  }
+  resizeCanvas();
+  window.addEventListener('resize', resizeCanvas);
   let t=0;
   function loop(){
+    resizeCanvas();
     const w=cvs.width, h=cvs.height;
     ctx.fillStyle = '#000';
     ctx.fillRect(0,0,w,h);

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
     </figure>
 
     <div class="crt">
-      <canvas id="heroCanvas" width="640" height="360" aria-label="Animación retro"></canvas>
+      <canvas id="heroCanvas" data-aspect="16:9" aria-label="Animación retro"></canvas>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- remove fixed dimensions from the hero canvas markup in favor of a data aspect attribute
- add responsive CSS so the hero canvas scales with its container
- set the canvas dimensions from script based on available width and update them on resize before drawing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e119f8748c832bb936eddd6aae7fcf