### PR TITLE
Ensure .btn elements use retro typeface

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -44,7 +44,7 @@ a{color:var(--accent)}
 #heroCanvas{width:100%;max-width:640px;height:auto}
 h1,h2,h3{color:var(--primary);text-shadow:0 0 10px var(--primary)}
 .subtitle{opacity:.9}
-.btn{display:inline-block;text-decoration:none;color:#000;background:var(--accent2);padding:12px 16px;border:2px solid #000;box-shadow:4px 4px 0 #000;transition:transform .05s}
+.btn{display:inline-block;text-decoration:none;color:#000;background:var(--accent2);padding:12px 16px;border:2px solid #000;box-shadow:4px 4px 0 #000;transition:transform .05s;font-family:"Press Start 2P", system-ui, sans-serif}
 .btn:hover{transform:translate(-2px,-2px);box-shadow:6px 6px 0 #000}
 .btn.cta{background:var(--accent)}
 .glow{animation:glow 2s ease-in-out infinite alternate}


### PR DESCRIPTION
## Summary
- add the retro Press Start 2P font-family to the shared .btn rule so buttons keep consistent typography

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e11d66927c832ba3d8acbfcecfb7ad