### PR TITLE
Simplify retro pages and document sections in Spanish

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,74 +1,295 @@
-
-:root{
-  --bg:#000000;
-  --fg:#cde7d0;
-  --primary:#00ff00;
-  --accent:#ff00ff;
-  --accent2:#ffff00;
-  --glass:rgba(0,0,0,0.6);
-  --border:rgba(255,255,255,0.08);
-}
-*{box-sizing:border-box}
-html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font-family:"Press Start 2P", system-ui, sans-serif;line-height:1.6}
-a{color:var(--accent)}
-.container{width:100%;max-width:1100px;margin:0 auto;padding:20px}
-.navbar{position:sticky;top:0;z-index:1000;background:var(--glass);backdrop-filter: blur(6px);border-bottom:1px solid var(--border)}
-.nav-inner{display:flex;align-items:center;justify-content:space-between;gap:12px}
-.brand{display:flex;align-items:center;gap:10px;text-decoration:none;color:var(--fg)}
-.brand-logo{display:inline-block;width:28px;height:28px;object-fit:contain;image-rendering:pixelated;border:2px solid #000;box-shadow:0 0 10px var(--accent);background:#000}
-.brand-text{letter-spacing:1px}
-.nav-desktop{display:flex;gap:18px}
-.nav-desktop a{text-decoration:none;color:var(--fg);padding:12px 8px;border-bottom:2px solid transparent}
-.nav-desktop a:hover{color:var(--accent2);text-shadow:0 0 8px var(--accent2)}
-.hamburger{display:none;background:transparent;border:0;cursor:pointer;padding:10px}
-.hamburger span{display:block;width:22px;height:2px;background:var(--fg);margin:4px 0}
-
-.nav-mobile{display:none;flex-direction:column;gap:12px;padding:10px 20px;background:var(--glass);border-bottom:1px solid var(--border)}
-.nav-mobile a{text-decoration:none;color:var(--fg);padding:10px 0;border-bottom:1px dashed var(--border)}
-
-@media (max-width: 820px){
-  .nav-desktop{display:none}
-  .hamburger{display:block}
-  .nav-mobile[aria-hidden="false"], .nav-mobile:not([hidden]){display:flex}
+/* Importa la tipografía retro desde Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+/* Paleta retro y tipografía global */
+:root {
+  --fondo: #000;
+  --texto: #cde7d0;
+  --verde: #00ff00;
+  --magenta: #ff00ff;
+  --amarillo: #ffff00;
+  --vidrio: rgba(0, 0, 0, 0.65);
+  --borde: rgba(255, 255, 255, 0.08);
+  font-family: "Press Start 2P", system-ui, sans-serif;
 }
 
-@media (max-width: 480px){
-  .hero-logo img{width:140px}
-  .hero-logo figcaption{font-size:.6rem}
+/* Ajustes básicos para toda la página */
+* {
+  box-sizing: border-box;
 }
 
-.hero{display:grid;gap:20px;place-items:center;min-height:70dvh;text-align:center;padding-top:30px}
-.hero-logo{display:grid;place-items:center;gap:6px;margin:0}
-.hero-logo img{width:180px;height:auto;image-rendering:pixelated;filter:drop-shadow(0 0 6px var(--accent))}
-.hero-logo figcaption{margin:0;font-size:.7rem;color:var(--accent2);text-shadow:0 0 6px rgba(255,255,0,0.4)}
-#heroCanvas{width:100%;max-width:640px;height:auto}
-h1,h2,h3{color:var(--primary);text-shadow:0 0 10px var(--primary)}
-.subtitle{opacity:.9}
-.btn{display:inline-block;text-decoration:none;color:#000;background:var(--accent2);padding:12px 16px;border:2px solid #000;box-shadow:4px 4px 0 #000;transition:transform .05s;font-family:"Press Start 2P", system-ui, sans-serif}
-.btn:hover{transform:translate(-2px,-2px);box-shadow:6px 6px 0 #000}
-.btn.cta{background:var(--accent)}
-.glow{animation:glow 2s ease-in-out infinite alternate}
-@keyframes glow{from{text-shadow:0 0 4px var(--primary)}to{text-shadow:0 0 14px var(--primary)}}
+body {
+  margin: 0;
+  background: var(--fondo);
+  color: var(--texto);
+  line-height: 1.6;
+}
 
-.crt{position:relative;border:2px solid var(--border);padding:8px}
-.crt::after{content:"";position:absolute;inset:0;background:linear-gradient(transparent 50%, rgba(255,255,255,.04) 50%);background-size:100% 4px;pointer-events:none}
+a {
+  color: var(--magenta);
+}
 
-.features .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;list-style:none;padding:0;margin:20px 0}
-.features .cards li{border:1px solid var(--border);padding:16px;background:rgba(255,255,255,0.02)}
+/* Contenedor fluido y centrado */
+.contenedor {
+  width: min(100%, 1040px);
+  margin: 0 auto;
+  padding: 20px;
+}
 
-.page h1{margin-top:24px}
-.lead{opacity:.95;margin-bottom:18px}
-.about-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px}
+/* Barra de navegación fija */
+.barra {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--vidrio);
+  border-bottom: 1px solid var(--borde);
+  backdrop-filter: blur(6px);
+}
 
-.grid.projects{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:18px}
-.project{border:1px solid var(--border);padding:16px;background:rgba(255,255,255,0.02)}
-.project h3{margin-top:0;color:var(--accent2);text-shadow:0 0 6px var(--accent2)}
+/* Distribución interna de la barra */
+.barra__contenido {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
 
-.contact{display:grid;gap:12px;max-width:520px}
-.contact input,.contact textarea{width:100%;padding:10px;border:2px solid #000;background:#0a0a0a;color:var(--fg)}
-.contact input:focus,.contact textarea:focus{outline:none;border-color:var(--accent);box-shadow:0 0 8px var(--accent)}
-.note{opacity:.7;font-size:.8rem}
+/* Marca y logotipo */
+.marca {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--texto);
+  text-decoration: none;
+}
 
-.footer{margin-top:40px;border-top:1px solid var(--border);background:rgba(255,255,255,0.02)}
-.footer-inner{display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap}
-.socials a{margin-right:12px}
+.marca__logo {
+  width: 28px;
+  height: 28px;
+  border: 2px solid #000;
+  image-rendering: pixelated;
+  box-shadow: 0 0 10px var(--verde);
+  background: #000;
+}
+
+/* Navegación horizontal */
+.enlaces {
+  display: flex;
+  gap: 16px;
+}
+
+.enlaces a {
+  text-decoration: none;
+  color: var(--texto);
+  padding: 12px 6px;
+}
+
+.enlaces a:hover {
+  color: var(--amarillo);
+  text-shadow: 0 0 6px var(--amarillo);
+}
+
+/* Botón hamburguesa */
+.menu {
+  display: none;
+  background: none;
+  border: 0;
+  padding: 8px;
+  cursor: pointer;
+}
+
+.menu span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  margin: 4px 0;
+  background: var(--texto);
+}
+
+/* Menú móvil plegable */
+.enlaces--movil {
+  display: none;
+  flex-direction: column;
+  padding: 12px 20px 20px;
+  border-bottom: 1px solid var(--borde);
+  background: var(--vidrio);
+}
+
+.enlaces--movil a {
+  border-bottom: 1px dashed var(--borde);
+  padding: 10px 0;
+}
+
+/* Sección hero */
+.hero {
+  display: grid;
+  gap: 20px;
+  place-items: center;
+  text-align: center;
+  padding: 40px 0 20px;
+}
+
+.hero__texto {
+  opacity: 0.9;
+}
+
+.hero__figura {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.hero__figura img {
+  width: 180px;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 0 6px var(--magenta));
+}
+
+.hero__figura figcaption {
+  font-size: 0.65rem;
+  color: var(--amarillo);
+}
+
+/* Botones principales */
+.boton {
+  display: inline-block;
+  padding: 12px 16px;
+  background: var(--amarillo);
+  color: #000;
+  border: 2px solid #000;
+  box-shadow: 4px 4px 0 #000;
+  text-decoration: none;
+}
+
+.boton:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 #000;
+}
+
+/* Efecto de brillo en el título */
+.brillo {
+  color: var(--verde);
+  text-shadow: 0 0 10px var(--verde);
+  animation: glow 2s ease-in-out infinite alternate;
+}
+
+@keyframes glow {
+  from { text-shadow: 0 0 4px var(--verde); }
+  to { text-shadow: 0 0 16px var(--verde); }
+}
+
+/* Marco estilo CRT */
+.crt {
+  position: relative;
+  border: 2px solid var(--borde);
+  padding: 8px;
+}
+
+.crt::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(transparent 50%, rgba(255, 255, 255, 0.04) 50%);
+  background-size: 100% 4px;
+}
+
+/* Listados de tarjetas */
+.tarjetas ul,
+.tarjetas--dobles,
+.rejilla {
+  display: grid;
+  gap: 16px;
+  padding: 0;
+  margin: 20px 0 0;
+  list-style: none;
+}
+
+.tarjetas ul {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.tarjetas--dobles {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.rejilla {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.tarjetas li,
+.tarjetas--dobles article,
+.rejilla article {
+  border: 1px solid var(--borde);
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* Estilos específicos de página */
+.pagina h1 {
+  margin-top: 24px;
+}
+
+.lead {
+  opacity: 0.95;
+  margin-bottom: 18px;
+}
+
+/* Formulario de contacto */
+.formulario {
+  display: grid;
+  gap: 12px;
+  max-width: 520px;
+}
+
+.formulario input,
+.formulario textarea {
+  width: 100%;
+  padding: 10px;
+  border: 2px solid #000;
+  background: #0a0a0a;
+  color: var(--texto);
+}
+
+.formulario input:focus,
+.formulario textarea:focus {
+  outline: none;
+  border-color: var(--magenta);
+  box-shadow: 0 0 8px var(--magenta);
+}
+
+.nota {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+/* Pie de página */
+.pie {
+  margin-top: 40px;
+  border-top: 1px solid var(--borde);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.pie__contenido {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.pie__redes a {
+  margin-right: 12px;
+}
+
+/* Ajustes para móviles */
+@media (max-width: 820px) {
+  .enlaces { display: none; }
+  .menu { display: block; }
+  .enlaces--movil[aria-hidden="false"],
+  .enlaces--movil:not([hidden]) { display: flex; }
+}
+
+@media (max-width: 480px) {
+  .hero__figura img { width: 140px; }
+  .hero__figura figcaption { font-size: 0.55rem; }
+}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,71 +1,74 @@
+// --- Variables base de navegación y pie ---
+const barra = document.getElementById('navbar');
+const botonMenu = document.getElementById('hamburger');
+const menuMovil = document.getElementById('mobileMenu');
+const anio = document.getElementById('year');
 
-// Sticky navbar solidify on scroll, mobile menu toggle, year
-const navbar = document.getElementById('navbar');
-const hamburger = document.getElementById('hamburger');
-const mobileMenu = document.getElementById('mobileMenu');
-const yearEl = document.getElementById('year');
+// --- Actualiza el año automáticamente ---
+if (anio) anio.textContent = new Date().getFullYear();
 
-yearEl && (yearEl.textContent = new Date().getFullYear());
-
-let lastY = window.scrollY;
+// --- Ajusta la opacidad de la barra al hacer scroll ---
 window.addEventListener('scroll', () => {
-  const y = window.scrollY;
-  if (!navbar) return;
-  navbar.style.background = y > 12 ? 'rgba(0,0,0,0.78)' : 'rgba(0,0,0,0.6)';
-  lastY = y;
+  if (!barra) return;
+  barra.style.background = window.scrollY > 12 ? 'rgba(0,0,0,0.78)' : 'rgba(0,0,0,0.65)';
 });
 
-if (hamburger && mobileMenu) {
-  hamburger.addEventListener('click', () => {
-    const isOpen = hamburger.getAttribute('aria-expanded') === 'true';
-    hamburger.setAttribute('aria-expanded', String(!isOpen));
-    if (isOpen) {
-      mobileMenu.setAttribute('hidden', '');
-      mobileMenu.setAttribute('aria-hidden', 'true');
+// --- Alterna el menú móvil en pantallas pequeñas ---
+if (botonMenu && menuMovil) {
+  botonMenu.addEventListener('click', () => {
+    const abierto = botonMenu.getAttribute('aria-expanded') === 'true';
+    botonMenu.setAttribute('aria-expanded', String(!abierto));
+    if (abierto) {
+      menuMovil.setAttribute('hidden', '');
+      menuMovil.setAttribute('aria-hidden', 'true');
     } else {
-      mobileMenu.removeAttribute('hidden');
-      mobileMenu.setAttribute('aria-hidden', 'false');
+      menuMovil.removeAttribute('hidden');
+      menuMovil.setAttribute('aria-hidden', 'false');
     }
   });
 }
 
-// Minimal retro hero canvas animation (no p5 here to keep homepage light)
-(function(){
-  const cvs = document.getElementById('heroCanvas');
-  if(!cvs) return;
-  const ctx = cvs.getContext('2d');
-  const aspectRatio = 16 / 9;
-  function resizeCanvas(){
-    const parentWidth = cvs.parentElement ? cvs.parentElement.clientWidth : 0;
-    const availableWidth = parentWidth || cvs.clientWidth || 640;
-    const width = Math.max(1, Math.min(availableWidth, 640));
-    const height = Math.max(1, Math.round(width / aspectRatio));
-    if(cvs.width !== width || cvs.height !== height){
-      cvs.width = width;
-      cvs.height = height;
-    }
-  }
-  resizeCanvas();
-  window.addEventListener('resize', resizeCanvas);
-  let t=0;
-  function loop(){
-    resizeCanvas();
-    const w=cvs.width, h=cvs.height;
+// --- Animación retro sencilla en el canvas del hero ---
+(() => {
+  const canvas = document.getElementById('heroCanvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const proporcion = 16 / 9;
+
+  // Ajusta el tamaño del canvas según el ancho disponible
+  const redimensionar = () => {
+    const ancho = Math.min(canvas.parentElement?.clientWidth || 640, 640);
+    const alto = Math.round(ancho / proporcion);
+    canvas.width = ancho;
+    canvas.height = alto;
+  };
+
+  redimensionar();
+  window.addEventListener('resize', redimensionar);
+
+  let t = 0;
+  const dibujar = () => {
+    redimensionar();
+    const { width: w, height: h } = canvas;
     ctx.fillStyle = '#000';
-    ctx.fillRect(0,0,w,h);
-    // starfield
-    for(let i=0;i<120;i++){
-      const x = (i*53 + t*2) % w;
-      const y = (i*97 + t) % h;
-      ctx.fillStyle = i%3===0 ? '#ff00ff' : (i%3===1 ? '#00ff00' : '#ffff00');
+    ctx.fillRect(0, 0, w, h);
+
+    // Campo de estrellas de colores
+    for (let i = 0; i < 120; i++) {
+      const x = (i * 47 + t * 2) % w;
+      const y = (i * 89 + t) % h;
+      ctx.fillStyle = i % 3 === 0 ? '#ff00ff' : i % 3 === 1 ? '#00ff00' : '#ffff00';
       ctx.fillRect(x, y, 2, 2);
     }
-    // title scanline pulse
+
+    // Línea luminosa que recorre la pantalla
     ctx.fillStyle = 'rgba(0,255,0,0.05)';
-    const sy = Math.abs(Math.sin(t*0.05))*h;
-    ctx.fillRect(0, sy, w, 8);
+    const lineaY = Math.abs(Math.sin(t * 0.05)) * h;
+    ctx.fillRect(0, lineaY, w, 8);
+
     t++;
-    requestAnimationFrame(loop);
-  }
-  loop();
+    requestAnimationFrame(dibujar);
+  };
+
+  dibujar();
 })();

--- a/contacto.html
+++ b/contacto.html
@@ -1,64 +1,62 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
+  <!-- Cabecera mínima con metadatos básicos -->
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Contacto · Retro Web</title>
-  <meta name="description" content="Escríbeme para colaborar en proyectos retro" />
-  <meta property="og:title" content="Contacto · Retro Web" />
-  <meta property="og:description" content="Escríbeme para colaborar en proyectos retro" />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="./assets/img/og-banner.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="icon" href="./assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="alternate icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAW4ElEQVR4nFWbzY4kWa6cP5InMmvuXEHSUhDuUgu9/0MJ0B+0mumucNLuwngiW9MoVE1mhLsf/hiNRnr8t//+b4RgAiIBBaFhMqgINEIECYhAiAwIoEdAUBIT/rcUZIACYPxNAYAQESD5miFBwigIf4QAgkAh31EFMXuJYKZJEqWIEYokIkCDIv0pCTIYiSQQ46sqUPhxMtjfJ0xChEAgAZn+os/k39UgiUgYgWbwmcUQKHzlCP8sIigK1hgTkBm08IPG/U5SBBH7Bz9gKIFENtsaURBp404QkQgbdM22pxMK7bOAFAiYHJQ2kMZGOAzkep6/PECybp60ByaI3DhIwRRIJDB+xM8h7kXsaRxJgmCoSmJggAx9oioADUQlwbC+scF7iKiNKCG7DwayAo0PjfbWuvEEmtiz+FSMHO3BJ7LRBBN/8fg4XEe2f9+L0b7O+E5KEQRZ4YvfMAcbM+/vbmwnKOyFAP/jx9iZ15tJ7uNJIiM/ZgptSMk5G4ioHwfo43bfN0KQAxKSk+GmJIJUJVEQCuy8QKnNk32wvWFsKJFJCOrmHEFu2GdCkb5W5rUxlc7V/Hw+ofbbuRiQSWbu0znyitw0dMhyggiRCVmbc0qcMcaftSqaTRft9dbwUfd5RcZcgJn11JCqjzfFECEiBhQks0Dh70T4pqE9tHzTXExIICsdgtqoCNbDwdlfsRkfciRkQKYPlosZtk362mtK1vg5F90gYwgFWXuKCCeqNlLmBxcyIgkcTpIRWTEkQYxIOfi0LogbhmEQWlj3QxNUOvxTW0XS0ZUUFRuWcjrkrQbhQ0ZeMCwijeC5bqsI/7+w4Uh7f5Ngc8qHgyI2cX8qyo16I8xNgcMYGW9i+jyzHkkDBsAkoUERZMRWjVikrY0S/10R63BxoiDnZjCHYDZMs4SL2sKonEYxQdh9XPzSPlv3oAyndcyi+f3Qfh7Ryj1DfH7lyjYLgDbGcdH+KzLwsWYDaGxxhqj4IOyNggtQ6dhzYEb4IQUPojLwVfwAaahmJimbwne/gJgXJ64FDNC5OaUQSpASSox+Qn3CtTzXJhMQ42j5RLK00TQcaQH1mu/aYQHRtXlDfolFbI4b6IJU+oaRhPNqwWfINAn4QfjDbBHObB+i9Tl0ZJAjlEnq3vvHs2YGxcSYUwgimlE5xzeKZs+lmev7xRoRucYAjtBPaaktNtoaGePwl0nGRXl7J4z2BJlFpiiV2eRWBCmZCCKHlm882uhRGmAJdFxplJvaVZ+8/ylZyxXy8OA0yRSPxlE5JlrPPntskNsZm/ULnuYnvveJZU4bGZ8afgSK+lisAnKMvFVJkf5Z7N9Z1JY3o7Y93hg3DnZ0hZB8Xc3rUiB7V6a4vjpUxsJYwMx+aijBTNLTRMAjp91MU5FLl+ZSSh+844csBYgiECcit6zp4+VFj/2uvW3PGMQqtghl8sqiMjhLfXORnHS+z0KcED2gHFquMBM+VOpGjUvpTanKIFSGKTnem6RaPDFmkkqOHnrTJoBQ/1TqTKKbbWbcFQiIBoLzQc6L5gtiLFGI9UaW629mEkpOJFXBicPJ4JXFaz9TGwEPDs+meQRVQyMOMDNMhKn2Bzyh5OpTBLU4YKD1td4zvKvJZ3jCYdVxiBhCQ/dAFhHDM0u093kWSpwiaep97Oa11OyXt3bH1v3aHuFsyJ9MzileBKeSrwhOFa8ovs5x7qZ4CB6GZ4qDaERrXBmWmmoW3DIgzBUSeEWSwhG24NoS1c15gt9fQ7wdUUwwg91bYcobouJytvikYnzYgEv5iYvmgNaDRnd7Ihz7+2BBpT38ivLhK3nV4TuTV7z4dYqvKLocAb8lHpo/GUrD00EhnpDb7jCAnUx3hileJJXJC0faSwbbkfizHt4ZxLSBbuA9wCN+ZxD9uIpc5A/RMaRiy+WW8tB2g+EPG+x+euWI7eQyqa3lqeRUUllk+vDnHH7F4VcefmXxr69vXmn0/zOaf9D8zqQ0vGmYoWdZhpIT7uaqzPRe4dD/IvkeR9Uvlppr+EcH/yBQx4Is9AJxtbtIEzsD3shVTtrcF5/wF7EgWNvVcdvZIC9nj3RalNHgZHAyeZ0g88VXFa948f314u95+K+vf+G7XgjxP+NN1m/+wfDn9Obpw5uhxmILWk6RxpPM4IvgKw7fKv7exX+ZX0TCH2r+R//TZOYJnhheAWrH/wmhWV7RS4KIbdm3NKbc2m/YH+d7WkDIZXm5BGf5fZ5b7goqoYqzf7KKVx5ep/jOw69zeEXSCedLfCW8L+HR40ZkhtEgjZFbvn6mMeVEcVR86/D1HL7fjoBnDLZHZRbHiyfc/NQkM9AKnhJxW3dBdqAc1D8weBukQ2z/vhwry2UnEgsP4TCNTLIcnuesIU5xThKZ1CvN3yPhuJzx9+P2OIPzJM/W78Pjkrh8AIo6C3gEJ4uTXy6Hv4v4oxgN2a4PGYfTQ8XDeQdPFNEiehuoSRrI7XRH7g7Nrce8ZyysnIhYheR2Yk4S12RBpXn9MVOMU/5cFfUSVMFJ+lU8r+J/f4lXQX8lf/zn4P0yy4v/11SLmYecl+NT2iZngbeSjCK/kvwPyUzy5yT/6/8IjXg/w+9Ont+gd24LntTTZodbvrMtjOhZxrkHJhz+csUnJKeAA33Wgw5/wmpOlbu8ynBfnxAn//InmFfwnOD3d/DPEu9fQl9D/0vQlXQDvwaeJFVUD/CyrrjGTyCOwZXXgddBGfQT/PGvgRqet9Afe6hIRFm8WQ7A+PopjPwR1HuIhIdyl1tL9dv3PciUkHI4um8XOi4HkQ5xjju8KP87XgVV9FdyTjJfQb/g9y/gO+AreA70XodfRbaYZxnpDFIhxuX26gGvIk8y39uaF/A3Ee/kHeJR09ttGrqLCFeU7KuIDNnFW+10fBsnRp/uw1Inw9Fq3LVITIqp/JAeCmtup6hyNYgDcYCvIL5X2voO9BX0f0re30BZN43tDOPvSb6LnEAPZBubRyuUpHuMfMVG1naXFeg/im7BA/N/XeaMHMkTY8Am4T0r2Vu7OGUVus9qDL0izKyKNcGJtKwVednYSk7lUhjpMHehlfPzVcQJ4lcQFfCd8BX0t8gveB8bjFxxxRFv3v8EigNpvl7uxdlqa5zJBaz0VxUuXxOgv8lhkQN/FESjCXg5iqDdEm8XS6UrwqbZmA1tZ5mcjPz0+FJSJyzKhb3g5sa8P06SryS+ymB4kvxOR8EpeCWqhFcQjDUEHAE5YUOOwTVJP0y6MYraA5xyUoSlKzdkyeQwWfDVRAfxu8jv3r4h0T+38epajSCQnhWrk2jROSRFI0JNyM2dW9cy+4u0rhdHRJWR+culrV7+d3wl+RXEV8KvIL+L+HazoNf2m2kpKnY20JmkxhQ43aoGlrV8eNBhu0qLnLmt+RM2JkfwHVt2hf4okqFUtIb87ZYafN98BfpdRPZiTdAaKmH6Q4RyFePbe/thKtyS5qZCrffzwKmgXuU/X0X9/ZBnu7dcnRARbZobA3VMWyMtlCh2NHOV2sWLDyV/Zps0GRTBafoqS+zH+uDpoWd46bgJUvDC/UFNoNoW+CmkJmZZTy7v8U23NlqF8J8My1K14HRy/y7i+1CvpF4rXub92w96NUVweYrV8m6qfSjaDkE+w4oVLzuXre21PgqPthI5NMxUv4rzdcgviDQzJYt8FcraWYBnEhXpKrb/iwjO7ZejrtYn52r4wLGHz7QgUsecoE7456/FidSqald/+6iMxHrGsru5+2yzIrZTS38nB/JZ+T2uuLEPHWZ7kkXRSJfALLPH/rJAeh6WvLk3mPD0SHI0UlodFM6dvmiHhAoRsucjDf7uE0x8SMgD9bcX9V3Os1VmWD3wkfNYdUPeXdloQOO2VLhpCejQlkXRaU/n8WDDUrbcwl7Nbtlj/grO64v43cwM0UPWgTPweBbR+bjCKOmQceRtVWvMinM1wTINDQNfXIkm82dogUdXuSXO3k3u/MnKWpD3kOzhMZVlXM81/uyErNqufBV4YjOIYZheGU2fJF0l+OLDRkXFXyL1+BmXvHnYYqXL0l5u0+c/GWFaGenxV2TA0sTPpCYvV5drdfCZT44rtfN4hmfaYY49Pgi1aK1+v57UAFq1tsWoreuN7JreKZX8sxk3NZ9dgVWWbbmdOmylUJjCX1K07Sa39MRqBpFw7J/jQYUgNQbB1ep5uYn4tMp7gBB+2IDp/nDx+LKBzPOM8L2HHd02WNDtEdXg/G93arMTJsL7B34MzyQkMT0baTZ8j0va1f1NgoJnTHo8J3AKmpcsuG61PuCQvdNftjmmRK6MzP2aLC8VRY97bqmItmCpFDWFKlayjk80XOCLETOzSw4wNKlCiLMd29xnySBKjNKen9z08bMIXy92A4StFMFtsJKJ/jhOa0QHjSCTAz85FtgQUhIKC7asJD037Kzo1sgdlWQsG8yzSyt/OopEo+bz4JpG7XBnU3miqSyLGw1ZsvfuQWRhfeaBHobZtta6otrpYc+OV2Tke8+nIq0hwuSLnV8eDwvD5WLDvLB2T8tKyqQV2Q3BmWTmIdpiZUz6c5FEe5xuWzV0MN3ezJBBb9rO6r6Gh6eaUsM5qAdRzt1H9Mkb8bTGkrqClHhGTLcjrJueYT7GDqLtsJBTcQj3DuGfnysQeBfJAKQpZkT2oBNMi3yGqaYbh/kskDHW5MLTXr3EdBLZzG+HhmRJO0bMW3sA1/RZgqTHPINoI3jsqKbCQgqAGj0bAQ90+RDdop9mHkfltI3ct9rM8MC14EeOl+BYNlr5eye2IXtZMsjEOOR6knpgnkZP8BbWAh4jbpPEE5DDKA1ce8NgS+DlABM0D9HBrPo0SmLMByaHUDK97bigWzw96BHTIgokH3wemLfodzvSuoke+nFFSe0wFa0u6fOeZ7Xz6l1cStAje7ATva2sdCfxNF0Jf+6SQjWT7h0m7al3W5Q8tSSp3NT0BHk82+8/B2aINvES4nwVtQ3X1SYJo/j7z8eG7KbfYz6hQO/Hnn6G/v24BPcwz9AjZppZvmUQBvUy0MWJIwFP01XeBRqXDW/EyKTmncx5eN4H8jHADeTZzmwNcMpGymOpqrehugSul/1NLx6omfaUd8ZI7d0/4JmVsEW/xwfHJXceg+QzDY/HYfOI3++H+XN4ZvGgZUx4nEJ6/kLKlpYfzfbOM6B0WYqDnofuco9eD/oz+TpePIkWOqLa8lOH83ciPUM8Tb9evNKNTcaSmV1G6Kd5euARkyLnKlK9y113fS7RDM+fvWSq6Wc2Gobpe/g1TA9PN/M4UqaHeBsz5rn3d5XXLk0cdr6esA8TdO/yUxlhiSQej7pyv3zU9OMDB6aiUU09ZalpYN7t34ut7zb79ObqXzq8GTHvJE6TV+/bIYbeQ7cZpg+4dLib54HpBz2yMVr0I/SeNdrNAZdYM9MfEnfmIxfvLl54hj99OZN2vGRwKRWa8ufj+UyNZ9vUyvGN8mXZLIOza6tSoGnm9gNtDPGaYaIKeFboPCxl1uY0QP+A4ODvN1s2B7392dlexCxxDyyTdvrmv392WFnq7trm3acJr5ZMzDY6xWuGRwlLZqI8UfZej6WzKRvgKai3wey96tC96chihvnIkpUsl8Rcbv/eNBAw7Qh5bJRn+gcUtxy7/DXPswbSA4/V557ZcvhwFVUt1h2Jn3U1jddaWqa1iH4ndRLdGT/wjDuq+iD5rsOlpzd9oJ7HSxn1gOqzgeKeY8vh7YsjgOZcyV2PBzLzk6/2MszjkVq3m7Z7ONpl7nKMWQJ0c9+7zcY6454uCI7rd4xrsORc/p10Lblpl6PeQ2RZy1cZIO+mZ6a5dzzBxPEaXCTE82lSFDhsNVYhtCCMmLLYSeAFKtwTzPQd9toAjBnmgpuW/Y0wsPYDI/T8tOE3/HHGm9/kRkDc5kRCFaugisSUU48+qy8h0WNjJILejdcMOiFzV13yMXuM2I3Y+EHgMLF57yr+umRbb6/YR9089XdGY4BW++ftqJxn25TZaiBjzAdnxtR5u7KPIYWp/nGHwDYHDo+5q2prMWJ37+MnLyObea9+L3bNpelcgSX7syw13FbUdpj5SQXwNqq1qtiFDFcd9+7xEVD6bpXIDDB6fzaeDegyz+v9rTpXqHEVytUPbPcjYSpbYmZLT7sdjnYJi+zVOb2fl6useqiSqAxCkWG9/VnVNRp91Jjl9ve/lctjYsurYzIqCT2eTAOQO8uznH7z223vrt890NPb6GgrzU8bbhVpB7+0/71g/OEB2pb6w8TGixNWn3a9pIZ4xKRXYtWxczifcCSyISrtCURGmwXGYt1HAdONfCN4uXusHvpyAFaJ2I6V99UW3eIG48HrDlk1261ez2+oh8ZpnrWLk/5d6VaB1eONuLaUamDKXL3tUbfHPwuOXEU3vIQQbZ3PC8tWX7qcTlTSe6R95eTup9ub49yfIxhzCmkwgixyfTj8rt7davKRzbZsXsKjzbeJ/f/NVWKSZGQtzCSC5Mjlz5vjVnxSuXM2t65oiPH8PZdPA97W2ndyUu2oca3wutpY1LgLy+6knbcRYxqdgncQPKi3ybpviYRH5AoDWqA1dlhXuBHAGB8U7iQjvI+oCzOO3MkPD7CwwIoY3NKcO4K9euDnIsaBQPRdXb+rtLbTvgRl7vk88VF0Q0HHBbHwwbUkaZpJfTDDL25t2lz9bBXjO3eJFVtNbG6rK3rSUlnMR82KPdysEbhLUo7A3BqtHZHxV4nNoTtaILMh8nL7ldWdHmvAFWvVm057nVgpyyC3+aifymL5zdERsYxTbqZaUBtyyp+R2wVUtDvAsRJ6/KC/8dWfyztpum2491S52bkvLpkb+D2ijRD5xlfRmBsstQAjCykRaZU4LYjsurW9sRXToKtVev07FN4BiFwgNlCZtVzoWDCWaXRzD7idjtwX/IzanDrsYe97RIbbqwqvAqNrsQgjsffbyfSNSVaB3YcJmbC0ds/HBCk0+1aZn3qWJ+RGhtbS2qmQ8PaWaqXxmJ99XvyZ3pZ9pj0blLW90KeoMs/iwCfc9m3Bmb84YrlOxEfvOCYbZlOFtpZb7dWWKKvSe9ENVXa1blbJ9YPtC28DylzGY6t//nnlaXxt2KHLo1sQ7sdcxMblNZYnWGmOdYArxv9Xvm+lgB29xdLgxZxlpJlOk+Mc3dKVK4wsZ3c+m7Y6Ely4W37HQ2Pyow3hC5pwr4OxQxjF1bsfxGcBAtm4yqWzue+P3HvcoNW26+IDiJcnzz2wNjzlkcxnmMNWD1tq92LTuoWfIfYFxN0UudMkPhSa6aUVmUhmeFxau2EUq32149eexUsJYNDqHXq0Yfvz7uHl6bFveAzyyxafTHCpHpkjx059tRXsRhoSd+VfHwNdVuLB73D3BG8ztFMdhS0fbY/03AhYb4WBjm0kPq/c7kP6Rk722JwftavM9t/OWO+xxmqL8ogIIj5iZXxY6HzyV/vCVKw1b1p4C3U+SL6QZ9Tfkpw4Te9Emn2hKIMNv1vTub/ckrFE5XaCN2y5/Us7T1nQCl0vzOf94rieGN/0ziJmVaYfSvhDpmJfemzK0YGHL7n4MSvdw/ykmxN/I+Y6jk9FMT5eA9x9CNuW+pSrDZW1ZJCWwDbFagptZzU4T3pzMzcfnTImUmZ888nXm/OrICzqmYPM7Ntjl++jT4n0nvFP3uvODy7i68JCbcnLjcX77uPVJn/Sw71Keh9wnLAbCXfsvCPn1C0iuFXx74pcQfWyQB9m7c4Pw7C6Yzo/n1kAn09Y4NiB0P2xI2zSlXqrhcHLswwz0P0v72t2W56vE9N0MtfzEdtIbTX4d6sA32htQHqkAAAAAElFTkSuQmCC" />
   <link rel="stylesheet" href="./assets/css/styles.css" />
 </head>
-
 <body>
-<header class="navbar" id="navbar">
-  <div class="container nav-inner">
-    <a class="brand" href="./"><img class="brand-logo" src="./assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
-    <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
-      <span></span><span></span><span></span>
-    </button>
-    <nav class="nav-desktop">
+  <!-- Barra de navegación reutilizable -->
+  <header class="barra" id="navbar">
+    <div class="contenedor barra__contenido">
+      <a class="marca" href="./">
+        <img class="marca__logo" src="./assets/img/logo.png" alt="Retro Web" />
+        <span class="marca__texto">Retro Web</span>
+      </a>
+      <button class="menu" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
+        <span></span><span></span><span></span>
+      </button>
+      <nav class="enlaces">
+        <a href="./">Inicio</a>
+        <a href="./sobre.html">Sobre mí</a>
+        <a href="./portafolio.html">Portafolio</a>
+        <a href="./contacto.html">Contacto</a>
+      </nav>
+    </div>
+    <nav class="enlaces enlaces--movil" id="mobileMenu" hidden>
       <a href="./">Inicio</a>
       <a href="./sobre.html">Sobre mí</a>
       <a href="./portafolio.html">Portafolio</a>
       <a href="./contacto.html">Contacto</a>
     </nav>
-  </div>
-  <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="./">Inicio</a>
-    <a href="./sobre.html">Sobre mí</a>
-    <a href="./portafolio.html">Portafolio</a>
-    <a href="./contacto.html">Contacto</a>
-  </nav>
-</header>
+  </header>
 
-<main class="container page">
-  <h1>Contacto</h1>
-  <p class="lead">¿Colaboramos? Envíame un mensaje y te respondo.</p>
-  <form class="contact" action="https://formspree.io/f/maypljrp" method="POST">
-    <label>Nombre<input name="name" required></label>
-    <label>Email<input name="email" type="email" required></label>
-    <label>Mensaje<textarea name="message" rows="5" required></textarea></label>
-    <button class="btn" type="submit">Enviar</button>
-  </form>
-  <p class="note">* Puedes cambiar el endpoint de Formspree más tarde por el tuyo.</p>
-</main>
-<footer class="footer">
-  <div class="container footer-inner">
-    <p>© <span id="year"></span> Retro Web · Hecho por Alberto con vibes arcade de los 80.</p>
-    <div class="socials">
-      <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
+  <!-- Formulario de contacto -->
+  <main class="contenedor pagina">
+    <h1>Contacto</h1>
+    <p class="lead">¿Colaboramos? Envíame un mensaje y hablamos.</p>
+    <form class="formulario" action="https://formspree.io/f/maypljrp" method="post">
+      <label>Nombre<input name="name" required /></label>
+      <label>Correo<input name="email" type="email" required /></label>
+      <label>Mensaje<textarea name="message" rows="5" required></textarea></label>
+      <button class="boton" type="submit">Enviar</button>
+    </form>
+    <p class="nota">* Puedes sustituir el endpoint de Formspree por el tuyo cuando quieras.</p>
+  </main>
+
+  <!-- Pie de página con redes -->
+  <footer class="pie">
+    <div class="contenedor pie__contenido">
+      <p>© <span id="year"></span> Retro Web. Vibes arcade.</p>
+      <div class="pie__redes">
+        <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
+      </div>
     </div>
-  </div>
-</footer>
-<script src="./assets/js/script.js"></script>
+  </footer>
+  <script src="./assets/js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,78 +1,83 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
+  <!-- Cabecera mínima con metadatos básicos -->
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Inicio · Retro Web</title>
-  <meta name="description" content="Portafolio artístico con toques retro" />
-  <meta property="og:title" content="Inicio · Retro Web" />
-  <meta property="og:description" content="Portafolio artístico con toques retro" />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="./assets/img/og-banner.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="icon" href="./assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="alternate icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAW4ElEQVR4nFWbzY4kWa6cP5InMmvuXEHSUhDuUgu9/0MJ0B+0mumucNLuwngiW9MoVE1mhLsf/hiNRnr8t//+b4RgAiIBBaFhMqgINEIECYhAiAwIoEdAUBIT/rcUZIACYPxNAYAQESD5miFBwigIf4QAgkAh31EFMXuJYKZJEqWIEYokIkCDIv0pCTIYiSQQ46sqUPhxMtjfJ0xChEAgAZn+os/k39UgiUgYgWbwmcUQKHzlCP8sIigK1hgTkBm08IPG/U5SBBH7Bz9gKIFENtsaURBp404QkQgbdM22pxMK7bOAFAiYHJQ2kMZGOAzkep6/PECybp60ByaI3DhIwRRIJDB+xM8h7kXsaRxJgmCoSmJggAx9oioADUQlwbC+scF7iKiNKCG7DwayAo0PjfbWuvEEmtiz+FSMHO3BJ7LRBBN/8fg4XEe2f9+L0b7O+E5KEQRZ4YvfMAcbM+/vbmwnKOyFAP/jx9iZ15tJ7uNJIiM/ZgptSMk5G4ioHwfo43bfN0KQAxKSk+GmJIJUJVEQCuy8QKnNk32wvWFsKJFJCOrmHEFu2GdCkb5W5rUxlc7V/Hw+ofbbuRiQSWbu0znyitw0dMhyggiRCVmbc0qcMcaftSqaTRft9dbwUfd5RcZcgJn11JCqjzfFECEiBhQks0Dh70T4pqE9tHzTXExIICsdgtqoCNbDwdlfsRkfciRkQKYPlosZtk362mtK1vg5F90gYwgFWXuKCCeqNlLmBxcyIgkcTpIRWTEkQYxIOfi0LogbhmEQWlj3QxNUOvxTW0XS0ZUUFRuWcjrkrQbhQ0ZeMCwijeC5bqsI/7+w4Uh7f5Ngc8qHgyI2cX8qyo16I8xNgcMYGW9i+jyzHkkDBsAkoUERZMRWjVikrY0S/10R63BxoiDnZjCHYDZMs4SL2sKonEYxQdh9XPzSPlv3oAyndcyi+f3Qfh7Ryj1DfH7lyjYLgDbGcdH+KzLwsWYDaGxxhqj4IOyNggtQ6dhzYEb4IQUPojLwVfwAaahmJimbwne/gJgXJ64FDNC5OaUQSpASSox+Qn3CtTzXJhMQ42j5RLK00TQcaQH1mu/aYQHRtXlDfolFbI4b6IJU+oaRhPNqwWfINAn4QfjDbBHObB+i9Tl0ZJAjlEnq3vvHs2YGxcSYUwgimlE5xzeKZs+lmev7xRoRucYAjtBPaaktNtoaGePwl0nGRXl7J4z2BJlFpiiV2eRWBCmZCCKHlm882uhRGmAJdFxplJvaVZ+8/ylZyxXy8OA0yRSPxlE5JlrPPntskNsZm/ULnuYnvveJZU4bGZ8afgSK+lisAnKMvFVJkf5Z7N9Z1JY3o7Y93hg3DnZ0hZB8Xc3rUiB7V6a4vjpUxsJYwMx+aijBTNLTRMAjp91MU5FLl+ZSSh+844csBYgiECcit6zp4+VFj/2uvW3PGMQqtghl8sqiMjhLfXORnHS+z0KcED2gHFquMBM+VOpGjUvpTanKIFSGKTnem6RaPDFmkkqOHnrTJoBQ/1TqTKKbbWbcFQiIBoLzQc6L5gtiLFGI9UaW629mEkpOJFXBicPJ4JXFaz9TGwEPDs+meQRVQyMOMDNMhKn2Bzyh5OpTBLU4YKD1td4zvKvJZ3jCYdVxiBhCQ/dAFhHDM0u093kWSpwiaep97Oa11OyXt3bH1v3aHuFsyJ9MzileBKeSrwhOFa8ovs5x7qZ4CB6GZ4qDaERrXBmWmmoW3DIgzBUSeEWSwhG24NoS1c15gt9fQ7wdUUwwg91bYcobouJytvikYnzYgEv5iYvmgNaDRnd7Ihz7+2BBpT38ivLhK3nV4TuTV7z4dYqvKLocAb8lHpo/GUrD00EhnpDb7jCAnUx3hileJJXJC0faSwbbkfizHt4ZxLSBbuA9wCN+ZxD9uIpc5A/RMaRiy+WW8tB2g+EPG+x+euWI7eQyqa3lqeRUUllk+vDnHH7F4VcefmXxr69vXmn0/zOaf9D8zqQ0vGmYoWdZhpIT7uaqzPRe4dD/IvkeR9Uvlppr+EcH/yBQx4Is9AJxtbtIEzsD3shVTtrcF5/wF7EgWNvVcdvZIC9nj3RalNHgZHAyeZ0g88VXFa948f314u95+K+vf+G7XgjxP+NN1m/+wfDn9Obpw5uhxmILWk6RxpPM4IvgKw7fKv7exX+ZX0TCH2r+R//TZOYJnhheAWrH/wmhWV7RS4KIbdm3NKbc2m/YH+d7WkDIZXm5BGf5fZ5b7goqoYqzf7KKVx5ep/jOw69zeEXSCedLfCW8L+HR40ZkhtEgjZFbvn6mMeVEcVR86/D1HL7fjoBnDLZHZRbHiyfc/NQkM9AKnhJxW3dBdqAc1D8weBukQ2z/vhwry2UnEgsP4TCNTLIcnuesIU5xThKZ1CvN3yPhuJzx9+P2OIPzJM/W78Pjkrh8AIo6C3gEJ4uTXy6Hv4v4oxgN2a4PGYfTQ8XDeQdPFNEiehuoSRrI7XRH7g7Nrce8ZyysnIhYheR2Yk4S12RBpXn9MVOMU/5cFfUSVMFJ+lU8r+J/f4lXQX8lf/zn4P0yy4v/11SLmYecl+NT2iZngbeSjCK/kvwPyUzy5yT/6/8IjXg/w+9Ont+gd24LntTTZodbvrMtjOhZxrkHJhz+csUnJKeAA33Wgw5/wmpOlbu8ynBfnxAn//InmFfwnOD3d/DPEu9fQl9D/0vQlXQDvwaeJFVUD/CyrrjGTyCOwZXXgddBGfQT/PGvgRqet9Afe6hIRFm8WQ7A+PopjPwR1HuIhIdyl1tL9dv3PciUkHI4um8XOi4HkQ5xjju8KP87XgVV9FdyTjJfQb/g9y/gO+AreA70XodfRbaYZxnpDFIhxuX26gGvIk8y39uaF/A3Ee/kHeJR09ttGrqLCFeU7KuIDNnFW+10fBsnRp/uw1Inw9Fq3LVITIqp/JAeCmtup6hyNYgDcYCvIL5X2voO9BX0f0re30BZN43tDOPvSb6LnEAPZBubRyuUpHuMfMVG1naXFeg/im7BA/N/XeaMHMkTY8Am4T0r2Vu7OGUVus9qDL0izKyKNcGJtKwVednYSk7lUhjpMHehlfPzVcQJ4lcQFfCd8BX0t8gveB8bjFxxxRFv3v8EigNpvl7uxdlqa5zJBaz0VxUuXxOgv8lhkQN/FESjCXg5iqDdEm8XS6UrwqbZmA1tZ5mcjPz0+FJSJyzKhb3g5sa8P06SryS+ymB4kvxOR8EpeCWqhFcQjDUEHAE5YUOOwTVJP0y6MYraA5xyUoSlKzdkyeQwWfDVRAfxu8jv3r4h0T+38epajSCQnhWrk2jROSRFI0JNyM2dW9cy+4u0rhdHRJWR+culrV7+d3wl+RXEV8KvIL+L+HazoNf2m2kpKnY20JmkxhQ43aoGlrV8eNBhu0qLnLmt+RM2JkfwHVt2hf4okqFUtIb87ZYafN98BfpdRPZiTdAaKmH6Q4RyFePbe/thKtyS5qZCrffzwKmgXuU/X0X9/ZBnu7dcnRARbZobA3VMWyMtlCh2NHOV2sWLDyV/Zps0GRTBafoqS+zH+uDpoWd46bgJUvDC/UFNoNoW+CmkJmZZTy7v8U23NlqF8J8My1K14HRy/y7i+1CvpF4rXub92w96NUVweYrV8m6qfSjaDkE+w4oVLzuXre21PgqPthI5NMxUv4rzdcgviDQzJYt8FcraWYBnEhXpKrb/iwjO7ZejrtYn52r4wLGHz7QgUsecoE7456/FidSqald/+6iMxHrGsru5+2yzIrZTS38nB/JZ+T2uuLEPHWZ7kkXRSJfALLPH/rJAeh6WvLk3mPD0SHI0UlodFM6dvmiHhAoRsucjDf7uE0x8SMgD9bcX9V3Os1VmWD3wkfNYdUPeXdloQOO2VLhpCejQlkXRaU/n8WDDUrbcwl7Nbtlj/grO64v43cwM0UPWgTPweBbR+bjCKOmQceRtVWvMinM1wTINDQNfXIkm82dogUdXuSXO3k3u/MnKWpD3kOzhMZVlXM81/uyErNqufBV4YjOIYZheGU2fJF0l+OLDRkXFXyL1+BmXvHnYYqXL0l5u0+c/GWFaGenxV2TA0sTPpCYvV5drdfCZT44rtfN4hmfaYY49Pgi1aK1+v57UAFq1tsWoreuN7JreKZX8sxk3NZ9dgVWWbbmdOmylUJjCX1K07Sa39MRqBpFw7J/jQYUgNQbB1ep5uYn4tMp7gBB+2IDp/nDx+LKBzPOM8L2HHd02WNDtEdXg/G93arMTJsL7B34MzyQkMT0baTZ8j0va1f1NgoJnTHo8J3AKmpcsuG61PuCQvdNftjmmRK6MzP2aLC8VRY97bqmItmCpFDWFKlayjk80XOCLETOzSw4wNKlCiLMd29xnySBKjNKen9z08bMIXy92A4StFMFtsJKJ/jhOa0QHjSCTAz85FtgQUhIKC7asJD037Kzo1sgdlWQsG8yzSyt/OopEo+bz4JpG7XBnU3miqSyLGw1ZsvfuQWRhfeaBHobZtta6otrpYc+OV2Tke8+nIq0hwuSLnV8eDwvD5WLDvLB2T8tKyqQV2Q3BmWTmIdpiZUz6c5FEe5xuWzV0MN3ezJBBb9rO6r6Gh6eaUsM5qAdRzt1H9Mkb8bTGkrqClHhGTLcjrJueYT7GDqLtsJBTcQj3DuGfnysQeBfJAKQpZkT2oBNMi3yGqaYbh/kskDHW5MLTXr3EdBLZzG+HhmRJO0bMW3sA1/RZgqTHPINoI3jsqKbCQgqAGj0bAQ90+RDdop9mHkfltI3ct9rM8MC14EeOl+BYNlr5eye2IXtZMsjEOOR6knpgnkZP8BbWAh4jbpPEE5DDKA1ce8NgS+DlABM0D9HBrPo0SmLMByaHUDK97bigWzw96BHTIgokH3wemLfodzvSuoke+nFFSe0wFa0u6fOeZ7Xz6l1cStAje7ATva2sdCfxNF0Jf+6SQjWT7h0m7al3W5Q8tSSp3NT0BHk82+8/B2aINvES4nwVtQ3X1SYJo/j7z8eG7KbfYz6hQO/Hnn6G/v24BPcwz9AjZppZvmUQBvUy0MWJIwFP01XeBRqXDW/EyKTmncx5eN4H8jHADeTZzmwNcMpGymOpqrehugSul/1NLx6omfaUd8ZI7d0/4JmVsEW/xwfHJXceg+QzDY/HYfOI3++H+XN4ZvGgZUx4nEJ6/kLKlpYfzfbOM6B0WYqDnofuco9eD/oz+TpePIkWOqLa8lOH83ciPUM8Tb9evNKNTcaSmV1G6Kd5euARkyLnKlK9y113fS7RDM+fvWSq6Wc2Gobpe/g1TA9PN/M4UqaHeBsz5rn3d5XXLk0cdr6esA8TdO/yUxlhiSQej7pyv3zU9OMDB6aiUU09ZalpYN7t34ut7zb79ObqXzq8GTHvJE6TV+/bIYbeQ7cZpg+4dLib54HpBz2yMVr0I/SeNdrNAZdYM9MfEnfmIxfvLl54hj99OZN2vGRwKRWa8ufj+UyNZ9vUyvGN8mXZLIOza6tSoGnm9gNtDPGaYaIKeFboPCxl1uY0QP+A4ODvN1s2B7392dlexCxxDyyTdvrmv392WFnq7trm3acJr5ZMzDY6xWuGRwlLZqI8UfZej6WzKRvgKai3wey96tC96chihvnIkpUsl8Rcbv/eNBAw7Qh5bJRn+gcUtxy7/DXPswbSA4/V557ZcvhwFVUt1h2Jn3U1jddaWqa1iH4ndRLdGT/wjDuq+iD5rsOlpzd9oJ7HSxn1gOqzgeKeY8vh7YsjgOZcyV2PBzLzk6/2MszjkVq3m7Z7ONpl7nKMWQJ0c9+7zcY6454uCI7rd4xrsORc/p10Lblpl6PeQ2RZy1cZIO+mZ6a5dzzBxPEaXCTE82lSFDhsNVYhtCCMmLLYSeAFKtwTzPQd9toAjBnmgpuW/Y0wsPYDI/T8tOE3/HHGm9/kRkDc5kRCFaugisSUU48+qy8h0WNjJILejdcMOiFzV13yMXuM2I3Y+EHgMLF57yr+umRbb6/YR9089XdGY4BW++ftqJxn25TZaiBjzAdnxtR5u7KPIYWp/nGHwDYHDo+5q2prMWJ37+MnLyObea9+L3bNpelcgSX7syw13FbUdpj5SQXwNqq1qtiFDFcd9+7xEVD6bpXIDDB6fzaeDegyz+v9rTpXqHEVytUPbPcjYSpbYmZLT7sdjnYJi+zVOb2fl6useqiSqAxCkWG9/VnVNRp91Jjl9ve/lctjYsurYzIqCT2eTAOQO8uznH7z223vrt890NPb6GgrzU8bbhVpB7+0/71g/OEB2pb6w8TGixNWn3a9pIZ4xKRXYtWxczifcCSyISrtCURGmwXGYt1HAdONfCN4uXusHvpyAFaJ2I6V99UW3eIG48HrDlk1261ez2+oh8ZpnrWLk/5d6VaB1eONuLaUamDKXL3tUbfHPwuOXEU3vIQQbZ3PC8tWX7qcTlTSe6R95eTup9ub49yfIxhzCmkwgixyfTj8rt7davKRzbZsXsKjzbeJ/f/NVWKSZGQtzCSC5Mjlz5vjVnxSuXM2t65oiPH8PZdPA97W2ndyUu2oca3wutpY1LgLy+6knbcRYxqdgncQPKi3ybpviYRH5AoDWqA1dlhXuBHAGB8U7iQjvI+oCzOO3MkPD7CwwIoY3NKcO4K9euDnIsaBQPRdXb+rtLbTvgRl7vk88VF0Q0HHBbHwwbUkaZpJfTDDL25t2lz9bBXjO3eJFVtNbG6rK3rSUlnMR82KPdysEbhLUo7A3BqtHZHxV4nNoTtaILMh8nL7ldWdHmvAFWvVm057nVgpyyC3+aifymL5zdERsYxTbqZaUBtyyp+R2wVUtDvAsRJ6/KC/8dWfyztpum2491S52bkvLpkb+D2ijRD5xlfRmBsstQAjCykRaZU4LYjsurW9sRXToKtVev07FN4BiFwgNlCZtVzoWDCWaXRzD7idjtwX/IzanDrsYe97RIbbqwqvAqNrsQgjsffbyfSNSVaB3YcJmbC0ds/HBCk0+1aZn3qWJ+RGhtbS2qmQ8PaWaqXxmJ99XvyZ3pZ9pj0blLW90KeoMs/iwCfc9m3Bmb84YrlOxEfvOCYbZlOFtpZb7dWWKKvSe9ENVXa1blbJ9YPtC28DylzGY6t//nnlaXxt2KHLo1sQ7sdcxMblNZYnWGmOdYArxv9Xvm+lgB29xdLgxZxlpJlOk+Mc3dKVK4wsZ3c+m7Y6Ely4W37HQ2Pyow3hC5pwr4OxQxjF1bsfxGcBAtm4yqWzue+P3HvcoNW26+IDiJcnzz2wNjzlkcxnmMNWD1tq92LTuoWfIfYFxN0UudMkPhSa6aUVmUhmeFxau2EUq32149eexUsJYNDqHXq0Yfvz7uHl6bFveAzyyxafTHCpHpkjx059tRXsRhoSd+VfHwNdVuLB73D3BG8ztFMdhS0fbY/03AhYb4WBjm0kPq/c7kP6Rk722JwftavM9t/OWO+xxmqL8ogIIj5iZXxY6HzyV/vCVKw1b1p4C3U+SL6QZ9Tfkpw4Te9Emn2hKIMNv1vTub/ckrFE5XaCN2y5/Us7T1nQCl0vzOf94rieGN/0ziJmVaYfSvhDpmJfemzK0YGHL7n4MSvdw/ykmxN/I+Y6jk9FMT5eA9x9CNuW+pSrDZW1ZJCWwDbFagptZzU4T3pzMzcfnTImUmZ888nXm/OrICzqmYPM7Ntjl++jT4n0nvFP3uvODy7i68JCbcnLjcX77uPVJn/Sw71Keh9wnLAbCXfsvCPn1C0iuFXx74pcQfWyQB9m7c4Pw7C6Yzo/n1kAn09Y4NiB0P2xI2zSlXqrhcHLswwz0P0v72t2W56vE9N0MtfzEdtIbTX4d6sA32htQHqkAAAAAElFTkSuQmCC" />
   <link rel="stylesheet" href="./assets/css/styles.css" />
 </head>
-
 <body>
-<header class="navbar" id="navbar">
-  <div class="container nav-inner">
-    <a class="brand" href="./"><img class="brand-logo" src="./assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
-    <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
-      <span></span><span></span><span></span>
-    </button>
-    <nav class="nav-desktop">
+  <!-- Barra de navegación reutilizable -->
+  <header class="barra" id="navbar">
+    <div class="contenedor barra__contenido">
+      <a class="marca" href="./">
+        <img class="marca__logo" src="./assets/img/logo.png" alt="Retro Web" />
+        <span class="marca__texto">Retro Web</span>
+      </a>
+      <button class="menu" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
+        <span></span><span></span><span></span>
+      </button>
+      <nav class="enlaces">
+        <a href="./">Inicio</a>
+        <a href="./sobre.html">Sobre mí</a>
+        <a href="./portafolio.html">Portafolio</a>
+        <a href="./contacto.html">Contacto</a>
+      </nav>
+    </div>
+    <nav class="enlaces enlaces--movil" id="mobileMenu" hidden>
       <a href="./">Inicio</a>
       <a href="./sobre.html">Sobre mí</a>
       <a href="./portafolio.html">Portafolio</a>
       <a href="./contacto.html">Contacto</a>
     </nav>
-  </div>
-  <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="./">Inicio</a>
-    <a href="./sobre.html">Sobre mí</a>
-    <a href="./portafolio.html">Portafolio</a>
-    <a href="./contacto.html">Contacto</a>
-  </nav>
-</header>
+  </header>
 
-<main class="container">
-  <section class="hero">
-    <h1 class="glow">Retro Web</h1>
-    <p class="subtitle">Homenaje artístico al arcade de los 80</p>
-    <a class="btn cta" href="./portafolio.html">Ver Portafolio ochentañero</a>
+  <!-- Contenido principal con hero y puntos clave -->
+  <main class="contenedor">
+    <section class="hero">
+      <h1 class="brillo">Retro Web</h1>
+      <p class="hero__texto">Homenaje artístico al arcade de los 80</p>
+      <a class="boton" href="./portafolio.html">Ver Portafolio</a>
+      <figure class="hero__figura">
+        <img src="./assets/img/marcianito.svg" alt="Marcianito 8-bit" />
+        <figcaption>Nuestro guardián pixelado vigila la galaxia.</figcaption>
+      </figure>
+      <div class="crt">
+        <canvas id="heroCanvas" aria-label="Animación retro"></canvas>
+      </div>
+    </section>
 
-    <figure class="hero-logo">
-      <img src="./assets/img/marcianito.svg" alt="Marcianito 8-bit estilo invasión ochentera" />
-      <figcaption>Nuevo guardián pixelado con antenas neón y cinturón brillante.</figcaption>
-    </figure>
+    <section class="tarjetas">
+      <h2>Estética Arcade</h2>
+      <ul>
+        <li>
+          <h3>Pixel Art</h3>
+          <p>Tipografía y componentes inspirados en 8 bits.</p>
+        </li>
+        <li>
+          <h3>Neones</h3>
+          <p>Colores verde, magenta y amarillo sobre negro.</p>
+        </li>
+        <li>
+          <h3>Efecto CRT</h3>
+          <p>Brillo y líneas de escaneo para ambientar.</p>
+        </li>
+      </ul>
+    </section>
+  </main>
 
-    <div class="crt">
-      <canvas id="heroCanvas" data-aspect="16:9" aria-label="Animación retro"></canvas>
+  <!-- Pie de página con redes -->
+  <footer class="pie">
+    <div class="contenedor pie__contenido">
+      <p>© <span id="year"></span> Retro Web. Vibes arcade.</p>
+      <div class="pie__redes">
+        <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
+      </div>
     </div>
-  </section>
-
-  <section class="features">
-    <h2>Estética Arcade</h2>
-    <ul class="cards">
-      <li><h3>Pixel Art</h3><p>Tipografía y UI de inspiración 8‑bit.</p></li>
-      <li><h3>Neones</h3><p>Verde, magenta y amarillo vibrantes sobre negro.</p></li>
-      <li><h3>Vibes CRT</h3><p>Efectos de scanlines y glow sutil.</p></li>
-    </ul>
-  </section>
-</main>
-<footer class="footer">
-  <div class="container footer-inner">
-    <p>© <span id="year"></span> Retro Web · Hecho por Alberto con vibes arcade de los 80.</p>
-    <div class="socials">
-      <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
-    </div>
-  </div>
-</footer>
-<script src="./assets/js/script.js"></script>
+  </footer>
+  <script src="./assets/js/script.js"></script>
 </body>
 </html>

--- a/portafolio.html
+++ b/portafolio.html
@@ -1,89 +1,87 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
+  <!-- Cabecera mínima con metadatos básicos -->
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Portafolio · Retro Web</title>
-  <meta name="description" content="Seis proyectos p5.js inspirados en arcades míticos" />
-  <meta property="og:title" content="Portafolio · Retro Web" />
-  <meta property="og:description" content="Seis proyectos p5.js inspirados en arcades míticos" />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="./assets/img/og-banner.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="icon" href="./assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="alternate icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAW4ElEQVR4nFWbzY4kWa6cP5InMmvuXEHSUhDuUgu9/0MJ0B+0mumucNLuwngiW9MoVE1mhLsf/hiNRnr8t//+b4RgAiIBBaFhMqgINEIECYhAiAwIoEdAUBIT/rcUZIACYPxNAYAQESD5miFBwigIf4QAgkAh31EFMXuJYKZJEqWIEYokIkCDIv0pCTIYiSQQ46sqUPhxMtjfJ0xChEAgAZn+os/k39UgiUgYgWbwmcUQKHzlCP8sIigK1hgTkBm08IPG/U5SBBH7Bz9gKIFENtsaURBp404QkQgbdM22pxMK7bOAFAiYHJQ2kMZGOAzkep6/PECybp60ByaI3DhIwRRIJDB+xM8h7kXsaRxJgmCoSmJggAx9oioADUQlwbC+scF7iKiNKCG7DwayAo0PjfbWuvEEmtiz+FSMHO3BJ7LRBBN/8fg4XEe2f9+L0b7O+E5KEQRZ4YvfMAcbM+/vbmwnKOyFAP/jx9iZ15tJ7uNJIiM/ZgptSMk5G4ioHwfo43bfN0KQAxKSk+GmJIJUJVEQCuy8QKnNk32wvWFsKJFJCOrmHEFu2GdCkb5W5rUxlc7V/Hw+ofbbuRiQSWbu0znyitw0dMhyggiRCVmbc0qcMcaftSqaTRft9dbwUfd5RcZcgJn11JCqjzfFECEiBhQks0Dh70T4pqE9tHzTXExIICsdgtqoCNbDwdlfsRkfciRkQKYPlosZtk362mtK1vg5F90gYwgFWXuKCCeqNlLmBxcyIgkcTpIRWTEkQYxIOfi0LogbhmEQWlj3QxNUOvxTW0XS0ZUUFRuWcjrkrQbhQ0ZeMCwijeC5bqsI/7+w4Uh7f5Ngc8qHgyI2cX8qyo16I8xNgcMYGW9i+jyzHkkDBsAkoUERZMRWjVikrY0S/10R63BxoiDnZjCHYDZMs4SL2sKonEYxQdh9XPzSPlv3oAyndcyi+f3Qfh7Ryj1DfH7lyjYLgDbGcdH+KzLwsWYDaGxxhqj4IOyNggtQ6dhzYEb4IQUPojLwVfwAaahmJimbwne/gJgXJ64FDNC5OaUQSpASSox+Qn3CtTzXJhMQ42j5RLK00TQcaQH1mu/aYQHRtXlDfolFbI4b6IJU+oaRhPNqwWfINAn4QfjDbBHObB+i9Tl0ZJAjlEnq3vvHs2YGxcSYUwgimlE5xzeKZs+lmev7xRoRucYAjtBPaaktNtoaGePwl0nGRXl7J4z2BJlFpiiV2eRWBCmZCCKHlm882uhRGmAJdFxplJvaVZ+8/ylZyxXy8OA0yRSPxlE5JlrPPntskNsZm/ULnuYnvveJZU4bGZ8afgSK+lisAnKMvFVJkf5Z7N9Z1JY3o7Y93hg3DnZ0hZB8Xc3rUiB7V6a4vjpUxsJYwMx+aijBTNLTRMAjp91MU5FLl+ZSSh+844csBYgiECcit6zp4+VFj/2uvW3PGMQqtghl8sqiMjhLfXORnHS+z0KcED2gHFquMBM+VOpGjUvpTanKIFSGKTnem6RaPDFmkkqOHnrTJoBQ/1TqTKKbbWbcFQiIBoLzQc6L5gtiLFGI9UaW629mEkpOJFXBicPJ4JXFaz9TGwEPDs+meQRVQyMOMDNMhKn2Bzyh5OpTBLU4YKD1td4zvKvJZ3jCYdVxiBhCQ/dAFhHDM0u093kWSpwiaep97Oa11OyXt3bH1v3aHuFsyJ9MzileBKeSrwhOFa8ovs5x7qZ4CB6GZ4qDaERrXBmWmmoW3DIgzBUSeEWSwhG24NoS1c15gt9fQ7wdUUwwg91bYcobouJytvikYnzYgEv5iYvmgNaDRnd7Ihz7+2BBpT38ivLhK3nV4TuTV7z4dYqvKLocAb8lHpo/GUrD00EhnpDb7jCAnUx3hileJJXJC0faSwbbkfizHt4ZxLSBbuA9wCN+ZxD9uIpc5A/RMaRiy+WW8tB2g+EPG+x+euWI7eQyqa3lqeRUUllk+vDnHH7F4VcefmXxr69vXmn0/zOaf9D8zqQ0vGmYoWdZhpIT7uaqzPRe4dD/IvkeR9Uvlppr+EcH/yBQx4Is9AJxtbtIEzsD3shVTtrcF5/wF7EgWNvVcdvZIC9nj3RalNHgZHAyeZ0g88VXFa948f314u95+K+vf+G7XgjxP+NN1m/+wfDn9Obpw5uhxmILWk6RxpPM4IvgKw7fKv7exX+ZX0TCH2r+R//TZOYJnhheAWrH/wmhWV7RS4KIbdm3NKbc2m/YH+d7WkDIZXm5BGf5fZ5b7goqoYqzf7KKVx5ep/jOw69zeEXSCedLfCW8L+HR40ZkhtEgjZFbvn6mMeVEcVR86/D1HL7fjoBnDLZHZRbHiyfc/NQkM9AKnhJxW3dBdqAc1D8weBukQ2z/vhwry2UnEgsP4TCNTLIcnuesIU5xThKZ1CvN3yPhuJzx9+P2OIPzJM/W78Pjkrh8AIo6C3gEJ4uTXy6Hv4v4oxgN2a4PGYfTQ8XDeQdPFNEiehuoSRrI7XRH7g7Nrce8ZyysnIhYheR2Yk4S12RBpXn9MVOMU/5cFfUSVMFJ+lU8r+J/f4lXQX8lf/zn4P0yy4v/11SLmYecl+NT2iZngbeSjCK/kvwPyUzy5yT/6/8IjXg/w+9Ont+gd24LntTTZodbvrMtjOhZxrkHJhz+csUnJKeAA33Wgw5/wmpOlbu8ynBfnxAn//InmFfwnOD3d/DPEu9fQl9D/0vQlXQDvwaeJFVUD/CyrrjGTyCOwZXXgddBGfQT/PGvgRqet9Afe6hIRFm8WQ7A+PopjPwR1HuIhIdyl1tL9dv3PciUkHI4um8XOi4HkQ5xjju8KP87XgVV9FdyTjJfQb/g9y/gO+AreA70XodfRbaYZxnpDFIhxuX26gGvIk8y39uaF/A3Ee/kHeJR09ttGrqLCFeU7KuIDNnFW+10fBsnRp/uw1Inw9Fq3LVITIqp/JAeCmtup6hyNYgDcYCvIL5X2voO9BX0f0re30BZN43tDOPvSb6LnEAPZBubRyuUpHuMfMVG1naXFeg/im7BA/N/XeaMHMkTY8Am4T0r2Vu7OGUVus9qDL0izKyKNcGJtKwVednYSk7lUhjpMHehlfPzVcQJ4lcQFfCd8BX0t8gveB8bjFxxxRFv3v8EigNpvl7uxdlqa5zJBaz0VxUuXxOgv8lhkQN/FESjCXg5iqDdEm8XS6UrwqbZmA1tZ5mcjPz0+FJSJyzKhb3g5sa8P06SryS+ymB4kvxOR8EpeCWqhFcQjDUEHAE5YUOOwTVJP0y6MYraA5xyUoSlKzdkyeQwWfDVRAfxu8jv3r4h0T+38epajSCQnhWrk2jROSRFI0JNyM2dW9cy+4u0rhdHRJWR+culrV7+d3wl+RXEV8KvIL+L+HazoNf2m2kpKnY20JmkxhQ43aoGlrV8eNBhu0qLnLmt+RM2JkfwHVt2hf4okqFUtIb87ZYafN98BfpdRPZiTdAaKmH6Q4RyFePbe/thKtyS5qZCrffzwKmgXuU/X0X9/ZBnu7dcnRARbZobA3VMWyMtlCh2NHOV2sWLDyV/Zps0GRTBafoqS+zH+uDpoWd46bgJUvDC/UFNoNoW+CmkJmZZTy7v8U23NlqF8J8My1K14HRy/y7i+1CvpF4rXub92w96NUVweYrV8m6qfSjaDkE+w4oVLzuXre21PgqPthI5NMxUv4rzdcgviDQzJYt8FcraWYBnEhXpKrb/iwjO7ZejrtYn52r4wLGHz7QgUsecoE7456/FidSqald/+6iMxHrGsru5+2yzIrZTS38nB/JZ+T2uuLEPHWZ7kkXRSJfALLPH/rJAeh6WvLk3mPD0SHI0UlodFM6dvmiHhAoRsucjDf7uE0x8SMgD9bcX9V3Os1VmWD3wkfNYdUPeXdloQOO2VLhpCejQlkXRaU/n8WDDUrbcwl7Nbtlj/grO64v43cwM0UPWgTPweBbR+bjCKOmQceRtVWvMinM1wTINDQNfXIkm82dogUdXuSXO3k3u/MnKWpD3kOzhMZVlXM81/uyErNqufBV4YjOIYZheGU2fJF0l+OLDRkXFXyL1+BmXvHnYYqXL0l5u0+c/GWFaGenxV2TA0sTPpCYvV5drdfCZT44rtfN4hmfaYY49Pgi1aK1+v57UAFq1tsWoreuN7JreKZX8sxk3NZ9dgVWWbbmdOmylUJjCX1K07Sa39MRqBpFw7J/jQYUgNQbB1ep5uYn4tMp7gBB+2IDp/nDx+LKBzPOM8L2HHd02WNDtEdXg/G93arMTJsL7B34MzyQkMT0baTZ8j0va1f1NgoJnTHo8J3AKmpcsuG61PuCQvdNftjmmRK6MzP2aLC8VRY97bqmItmCpFDWFKlayjk80XOCLETOzSw4wNKlCiLMd29xnySBKjNKen9z08bMIXy92A4StFMFtsJKJ/jhOa0QHjSCTAz85FtgQUhIKC7asJD037Kzo1sgdlWQsG8yzSyt/OopEo+bz4JpG7XBnU3miqSyLGw1ZsvfuQWRhfeaBHobZtta6otrpYc+OV2Tke8+nIq0hwuSLnV8eDwvD5WLDvLB2T8tKyqQV2Q3BmWTmIdpiZUz6c5FEe5xuWzV0MN3ezJBBb9rO6r6Gh6eaUsM5qAdRzt1H9Mkb8bTGkrqClHhGTLcjrJueYT7GDqLtsJBTcQj3DuGfnysQeBfJAKQpZkT2oBNMi3yGqaYbh/kskDHW5MLTXr3EdBLZzG+HhmRJO0bMW3sA1/RZgqTHPINoI3jsqKbCQgqAGj0bAQ90+RDdop9mHkfltI3ct9rM8MC14EeOl+BYNlr5eye2IXtZMsjEOOR6knpgnkZP8BbWAh4jbpPEE5DDKA1ce8NgS+DlABM0D9HBrPo0SmLMByaHUDK97bigWzw96BHTIgokH3wemLfodzvSuoke+nFFSe0wFa0u6fOeZ7Xz6l1cStAje7ATva2sdCfxNF0Jf+6SQjWT7h0m7al3W5Q8tSSp3NT0BHk82+8/B2aINvES4nwVtQ3X1SYJo/j7z8eG7KbfYz6hQO/Hnn6G/v24BPcwz9AjZppZvmUQBvUy0MWJIwFP01XeBRqXDW/EyKTmncx5eN4H8jHADeTZzmwNcMpGymOpqrehugSul/1NLx6omfaUd8ZI7d0/4JmVsEW/xwfHJXceg+QzDY/HYfOI3++H+XN4ZvGgZUx4nEJ6/kLKlpYfzfbOM6B0WYqDnofuco9eD/oz+TpePIkWOqLa8lOH83ciPUM8Tb9evNKNTcaSmV1G6Kd5euARkyLnKlK9y113fS7RDM+fvWSq6Wc2Gobpe/g1TA9PN/M4UqaHeBsz5rn3d5XXLk0cdr6esA8TdO/yUxlhiSQej7pyv3zU9OMDB6aiUU09ZalpYN7t34ut7zb79ObqXzq8GTHvJE6TV+/bIYbeQ7cZpg+4dLib54HpBz2yMVr0I/SeNdrNAZdYM9MfEnfmIxfvLl54hj99OZN2vGRwKRWa8ufj+UyNZ9vUyvGN8mXZLIOza6tSoGnm9gNtDPGaYaIKeFboPCxl1uY0QP+A4ODvN1s2B7392dlexCxxDyyTdvrmv392WFnq7trm3acJr5ZMzDY6xWuGRwlLZqI8UfZej6WzKRvgKai3wey96tC96chihvnIkpUsl8Rcbv/eNBAw7Qh5bJRn+gcUtxy7/DXPswbSA4/V557ZcvhwFVUt1h2Jn3U1jddaWqa1iH4ndRLdGT/wjDuq+iD5rsOlpzd9oJ7HSxn1gOqzgeKeY8vh7YsjgOZcyV2PBzLzk6/2MszjkVq3m7Z7ONpl7nKMWQJ0c9+7zcY6454uCI7rd4xrsORc/p10Lblpl6PeQ2RZy1cZIO+mZ6a5dzzBxPEaXCTE82lSFDhsNVYhtCCMmLLYSeAFKtwTzPQd9toAjBnmgpuW/Y0wsPYDI/T8tOE3/HHGm9/kRkDc5kRCFaugisSUU48+qy8h0WNjJILejdcMOiFzV13yMXuM2I3Y+EHgMLF57yr+umRbb6/YR9089XdGY4BW++ftqJxn25TZaiBjzAdnxtR5u7KPIYWp/nGHwDYHDo+5q2prMWJ37+MnLyObea9+L3bNpelcgSX7syw13FbUdpj5SQXwNqq1qtiFDFcd9+7xEVD6bpXIDDB6fzaeDegyz+v9rTpXqHEVytUPbPcjYSpbYmZLT7sdjnYJi+zVOb2fl6useqiSqAxCkWG9/VnVNRp91Jjl9ve/lctjYsurYzIqCT2eTAOQO8uznH7z223vrt890NPb6GgrzU8bbhVpB7+0/71g/OEB2pb6w8TGixNWn3a9pIZ4xKRXYtWxczifcCSyISrtCURGmwXGYt1HAdONfCN4uXusHvpyAFaJ2I6V99UW3eIG48HrDlk1261ez2+oh8ZpnrWLk/5d6VaB1eONuLaUamDKXL3tUbfHPwuOXEU3vIQQbZ3PC8tWX7qcTlTSe6R95eTup9ub49yfIxhzCmkwgixyfTj8rt7davKRzbZsXsKjzbeJ/f/NVWKSZGQtzCSC5Mjlz5vjVnxSuXM2t65oiPH8PZdPA97W2ndyUu2oca3wutpY1LgLy+6knbcRYxqdgncQPKi3ybpviYRH5AoDWqA1dlhXuBHAGB8U7iQjvI+oCzOO3MkPD7CwwIoY3NKcO4K9euDnIsaBQPRdXb+rtLbTvgRl7vk88VF0Q0HHBbHwwbUkaZpJfTDDL25t2lz9bBXjO3eJFVtNbG6rK3rSUlnMR82KPdysEbhLUo7A3BqtHZHxV4nNoTtaILMh8nL7ldWdHmvAFWvVm057nVgpyyC3+aifymL5zdERsYxTbqZaUBtyyp+R2wVUtDvAsRJ6/KC/8dWfyztpum2491S52bkvLpkb+D2ijRD5xlfRmBsstQAjCykRaZU4LYjsurW9sRXToKtVev07FN4BiFwgNlCZtVzoWDCWaXRzD7idjtwX/IzanDrsYe97RIbbqwqvAqNrsQgjsffbyfSNSVaB3YcJmbC0ds/HBCk0+1aZn3qWJ+RGhtbS2qmQ8PaWaqXxmJ99XvyZ3pZ9pj0blLW90KeoMs/iwCfc9m3Bmb84YrlOxEfvOCYbZlOFtpZb7dWWKKvSe9ENVXa1blbJ9YPtC28DylzGY6t//nnlaXxt2KHLo1sQ7sdcxMblNZYnWGmOdYArxv9Xvm+lgB29xdLgxZxlpJlOk+Mc3dKVK4wsZ3c+m7Y6Ely4W37HQ2Pyow3hC5pwr4OxQxjF1bsfxGcBAtm4yqWzue+P3HvcoNW26+IDiJcnzz2wNjzlkcxnmMNWD1tq92LTuoWfIfYFxN0UudMkPhSa6aUVmUhmeFxau2EUq32149eexUsJYNDqHXq0Yfvz7uHl6bFveAzyyxafTHCpHpkjx059tRXsRhoSd+VfHwNdVuLB73D3BG8ztFMdhS0fbY/03AhYb4WBjm0kPq/c7kP6Rk722JwftavM9t/OWO+xxmqL8ogIIj5iZXxY6HzyV/vCVKw1b1p4C3U+SL6QZ9Tfkpw4Te9Emn2hKIMNv1vTub/ckrFE5XaCN2y5/Us7T1nQCl0vzOf94rieGN/0ziJmVaYfSvhDpmJfemzK0YGHL7n4MSvdw/ykmxN/I+Y6jk9FMT5eA9x9CNuW+pSrDZW1ZJCWwDbFagptZzU4T3pzMzcfnTImUmZ888nXm/OrICzqmYPM7Ntjl++jT4n0nvFP3uvODy7i68JCbcnLjcX77uPVJn/Sw71Keh9wnLAbCXfsvCPn1C0iuFXx74pcQfWyQB9m7c4Pw7C6Yzo/n1kAn09Y4NiB0P2xI2zSlXqrhcHLswwz0P0v72t2W56vE9N0MtfzEdtIbTX4d6sA32htQHqkAAAAAElFTkSuQmCC" />
   <link rel="stylesheet" href="./assets/css/styles.css" />
 </head>
-
 <body>
-<header class="navbar" id="navbar">
-  <div class="container nav-inner">
-    <a class="brand" href="./"><img class="brand-logo" src="./assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
-    <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
-      <span></span><span></span><span></span>
-    </button>
-    <nav class="nav-desktop">
+  <!-- Barra de navegación reutilizable -->
+  <header class="barra" id="navbar">
+    <div class="contenedor barra__contenido">
+      <a class="marca" href="./">
+        <img class="marca__logo" src="./assets/img/logo.png" alt="Retro Web" />
+        <span class="marca__texto">Retro Web</span>
+      </a>
+      <button class="menu" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
+        <span></span><span></span><span></span>
+      </button>
+      <nav class="enlaces">
+        <a href="./">Inicio</a>
+        <a href="./sobre.html">Sobre mí</a>
+        <a href="./portafolio.html">Portafolio</a>
+        <a href="./contacto.html">Contacto</a>
+      </nav>
+    </div>
+    <nav class="enlaces enlaces--movil" id="mobileMenu" hidden>
       <a href="./">Inicio</a>
       <a href="./sobre.html">Sobre mí</a>
       <a href="./portafolio.html">Portafolio</a>
       <a href="./contacto.html">Contacto</a>
     </nav>
-  </div>
-  <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="./">Inicio</a>
-    <a href="./sobre.html">Sobre mí</a>
-    <a href="./portafolio.html">Portafolio</a>
-    <a href="./contacto.html">Contacto</a>
-  </nav>
-</header>
+  </header>
 
-<main class="container page">
-  <h1>Portafolio</h1>
-  <p class="lead">Seis mini‑proyectos en p5.js inspirados en las recreativas que marcaron los 80 en España.</p>
-  <div class="grid projects">
-<article class="project">
-  <h3>Space Invaders Recharged</h3>
-  <p>Los marcianitos nunca pasan de moda, pero ahora disparan con ritmo ochentañero.</p>
-  <a class="btn" href="./proyectos/space-invaders/">Abrir demo</a>
-</article>
-<article class="project">
-  <h3>Pac-Man Remix</h3>
-  <p>El laberinto sigue ahí, pero los fantasmas ahora bailan synthwave.</p>
-  <a class="btn" href="./proyectos/pacman/">Abrir demo</a>
-</article>
-<article class="project">
-  <h3>Donkey Kong Rampage</h3>
-  <p>De la obra al pixel: saltar, trepar y esquivar barriles retro con alma española.</p>
-  <a class="btn" href="./proyectos/donkey-kong/">Abrir demo</a>
-</article>
-<article class="project">
-  <h3>Galaga Reloaded</h3>
-  <p>Defiende la galaxia desde tu recreativa favorita, ahora con neones fosforitos.</p>
-  <a class="btn" href="./proyectos/galaga/">Abrir demo</a>
-</article>
-<article class="project">
-  <h3>Ghosts’n Goblins Revival</h3>
-  <p>Sir Arthur vuelve, en calzoncillos pixelados, a enfrentarse a demonios imposibles.</p>
-  <a class="btn" href="./proyectos/ghosts-goblins/">Abrir demo</a>
-</article>
-<article class="project">
-  <h3>Out Run Neo80</h3>
-  <p>Coge el Ferrari, pisa a fondo y recorre carreteras llenas de sol, palmeras y nostalgia.</p>
-  <a class="btn" href="./proyectos/outrun/">Abrir demo</a>
-</article>
-  </div>
-</main>
-<footer class="footer">
-  <div class="container footer-inner">
-    <p>© <span id="year"></span> Retro Web · Hecho por Alberto con vibes arcade de los 80.</p>
-    <div class="socials">
-      <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
+  <!-- Listado de proyectos destacados -->
+  <main class="contenedor pagina">
+    <h1>Portafolio</h1>
+    <p class="lead">Seis mini proyectos p5.js inspirados en recreativas míticas de los 80.</p>
+    <section class="rejilla">
+      <article>
+        <h3>Space Invaders Recharged</h3>
+        <p>Marcianitos con ritmo ochentañero y brillo neón.</p>
+        <a class="boton" href="./proyectos/space-invaders/">Abrir demo</a>
+      </article>
+      <article>
+        <h3>Pac-Man Remix</h3>
+        <p>El laberinto clásico al compás del synthwave.</p>
+        <a class="boton" href="./proyectos/pacman/">Abrir demo</a>
+      </article>
+      <article>
+        <h3>Donkey Kong Rampage</h3>
+        <p>Aventuras de barriles con alma de recreativa.</p>
+        <a class="boton" href="./proyectos/donkey-kong/">Abrir demo</a>
+      </article>
+      <article>
+        <h3>Galaga Reloaded</h3>
+        <p>Defiende la galaxia entre luces fosforitas.</p>
+        <a class="boton" href="./proyectos/galaga/">Abrir demo</a>
+      </article>
+      <article>
+        <h3>Ghosts’n Goblins Revival</h3>
+        <p>Sir Arthur vuelve a por demonios imposibles.</p>
+        <a class="boton" href="./proyectos/ghosts-goblins/">Abrir demo</a>
+      </article>
+      <article>
+        <h3>Out Run Neo80</h3>
+        <p>Ferrari rojo, palmeras y puestas de sol retro.</p>
+        <a class="boton" href="./proyectos/outrun/">Abrir demo</a>
+      </article>
+    </section>
+  </main>
+
+  <!-- Pie de página con redes -->
+  <footer class="pie">
+    <div class="contenedor pie__contenido">
+      <p>© <span id="year"></span> Retro Web. Vibes arcade.</p>
+      <div class="pie__redes">
+        <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
+      </div>
     </div>
-  </div>
-</footer>
-<script src="./assets/js/script.js"></script>
+  </footer>
+  <script src="./assets/js/script.js"></script>
 </body>
 </html>

--- a/sobre.html
+++ b/sobre.html
@@ -1,68 +1,65 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
+  <!-- Cabecera mínima con metadatos básicos -->
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Sobre mí · Retro Web</title>
-  <meta name="description" content="Conoce a Alberto y su universo arcade" />
-  <meta property="og:title" content="Sobre mí · Retro Web" />
-  <meta property="og:description" content="Conoce a Alberto y su universo arcade" />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="./assets/img/og-banner.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="icon" href="./assets/img/favicon.svg" type="image/svg+xml" />
-  <link rel="alternate icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAW4ElEQVR4nFWbzY4kWa6cP5InMmvuXEHSUhDuUgu9/0MJ0B+0mumucNLuwngiW9MoVE1mhLsf/hiNRnr8t//+b4RgAiIBBaFhMqgINEIECYhAiAwIoEdAUBIT/rcUZIACYPxNAYAQESD5miFBwigIf4QAgkAh31EFMXuJYKZJEqWIEYokIkCDIv0pCTIYiSQQ46sqUPhxMtjfJ0xChEAgAZn+os/k39UgiUgYgWbwmcUQKHzlCP8sIigK1hgTkBm08IPG/U5SBBH7Bz9gKIFENtsaURBp404QkQgbdM22pxMK7bOAFAiYHJQ2kMZGOAzkep6/PECybp60ByaI3DhIwRRIJDB+xM8h7kXsaRxJgmCoSmJggAx9oioADUQlwbC+scF7iKiNKCG7DwayAo0PjfbWuvEEmtiz+FSMHO3BJ7LRBBN/8fg4XEe2f9+L0b7O+E5KEQRZ4YvfMAcbM+/vbmwnKOyFAP/jx9iZ15tJ7uNJIiM/ZgptSMk5G4ioHwfo43bfN0KQAxKSk+GmJIJUJVEQCuy8QKnNk32wvWFsKJFJCOrmHEFu2GdCkb5W5rUxlc7V/Hw+ofbbuRiQSWbu0znyitw0dMhyggiRCVmbc0qcMcaftSqaTRft9dbwUfd5RcZcgJn11JCqjzfFECEiBhQks0Dh70T4pqE9tHzTXExIICsdgtqoCNbDwdlfsRkfciRkQKYPlosZtk362mtK1vg5F90gYwgFWXuKCCeqNlLmBxcyIgkcTpIRWTEkQYxIOfi0LogbhmEQWlj3QxNUOvxTW0XS0ZUUFRuWcjrkrQbhQ0ZeMCwijeC5bqsI/7+w4Uh7f5Ngc8qHgyI2cX8qyo16I8xNgcMYGW9i+jyzHkkDBsAkoUERZMRWjVikrY0S/10R63BxoiDnZjCHYDZMs4SL2sKonEYxQdh9XPzSPlv3oAyndcyi+f3Qfh7Ryj1DfH7lyjYLgDbGcdH+KzLwsWYDaGxxhqj4IOyNggtQ6dhzYEb4IQUPojLwVfwAaahmJimbwne/gJgXJ64FDNC5OaUQSpASSox+Qn3CtTzXJhMQ42j5RLK00TQcaQH1mu/aYQHRtXlDfolFbI4b6IJU+oaRhPNqwWfINAn4QfjDbBHObB+i9Tl0ZJAjlEnq3vvHs2YGxcSYUwgimlE5xzeKZs+lmev7xRoRucYAjtBPaaktNtoaGePwl0nGRXl7J4z2BJlFpiiV2eRWBCmZCCKHlm882uhRGmAJdFxplJvaVZ+8/ylZyxXy8OA0yRSPxlE5JlrPPntskNsZm/ULnuYnvveJZU4bGZ8afgSK+lisAnKMvFVJkf5Z7N9Z1JY3o7Y93hg3DnZ0hZB8Xc3rUiB7V6a4vjpUxsJYwMx+aijBTNLTRMAjp91MU5FLl+ZSSh+844csBYgiECcit6zp4+VFj/2uvW3PGMQqtghl8sqiMjhLfXORnHS+z0KcED2gHFquMBM+VOpGjUvpTanKIFSGKTnem6RaPDFmkkqOHnrTJoBQ/1TqTKKbbWbcFQiIBoLzQc6L5gtiLFGI9UaW629mEkpOJFXBicPJ4JXFaz9TGwEPDs+meQRVQyMOMDNMhKn2Bzyh5OpTBLU4YKD1td4zvKvJZ3jCYdVxiBhCQ/dAFhHDM0u093kWSpwiaep97Oa11OyXt3bH1v3aHuFsyJ9MzileBKeSrwhOFa8ovs5x7qZ4CB6GZ4qDaERrXBmWmmoW3DIgzBUSeEWSwhG24NoS1c15gt9fQ7wdUUwwg91bYcobouJytvikYnzYgEv5iYvmgNaDRnd7Ihz7+2BBpT38ivLhK3nV4TuTV7z4dYqvKLocAb8lHpo/GUrD00EhnpDb7jCAnUx3hileJJXJC0faSwbbkfizHt4ZxLSBbuA9wCN+ZxD9uIpc5A/RMaRiy+WW8tB2g+EPG+x+euWI7eQyqa3lqeRUUllk+vDnHH7F4VcefmXxr69vXmn0/zOaf9D8zqQ0vGmYoWdZhpIT7uaqzPRe4dD/IvkeR9Uvlppr+EcH/yBQx4Is9AJxtbtIEzsD3shVTtrcF5/wF7EgWNvVcdvZIC9nj3RalNHgZHAyeZ0g88VXFa948f314u95+K+vf+G7XgjxP+NN1m/+wfDn9Obpw5uhxmILWk6RxpPM4IvgKw7fKv7exX+ZX0TCH2r+R//TZOYJnhheAWrH/wmhWV7RS4KIbdm3NKbc2m/YH+d7WkDIZXm5BGf5fZ5b7goqoYqzf7KKVx5ep/jOw69zeEXSCedLfCW8L+HR40ZkhtEgjZFbvn6mMeVEcVR86/D1HL7fjoBnDLZHZRbHiyfc/NQkM9AKnhJxW3dBdqAc1D8weBukQ2z/vhwry2UnEgsP4TCNTLIcnuesIU5xThKZ1CvN3yPhuJzx9+P2OIPzJM/W78Pjkrh8AIo6C3gEJ4uTXy6Hv4v4oxgN2a4PGYfTQ8XDeQdPFNEiehuoSRrI7XRH7g7Nrce8ZyysnIhYheR2Yk4S12RBpXn9MVOMU/5cFfUSVMFJ+lU8r+J/f4lXQX8lf/zn4P0yy4v/11SLmYecl+NT2iZngbeSjCK/kvwPyUzy5yT/6/8IjXg/w+9Ont+gd24LntTTZodbvrMtjOhZxrkHJhz+csUnJKeAA33Wgw5/wmpOlbu8ynBfnxAn//InmFfwnOD3d/DPEu9fQl9D/0vQlXQDvwaeJFVUD/CyrrjGTyCOwZXXgddBGfQT/PGvgRqet9Afe6hIRFm8WQ7A+PopjPwR1HuIhIdyl1tL9dv3PciUkHI4um8XOi4HkQ5xjju8KP87XgVV9FdyTjJfQb/g9y/gO+AreA70XodfRbaYZxnpDFIhxuX26gGvIk8y39uaF/A3Ee/kHeJR09ttGrqLCFeU7KuIDNnFW+10fBsnRp/uw1Inw9Fq3LVITIqp/JAeCmtup6hyNYgDcYCvIL5X2voO9BX0f0re30BZN43tDOPvSb6LnEAPZBubRyuUpHuMfMVG1naXFeg/im7BA/N/XeaMHMkTY8Am4T0r2Vu7OGUVus9qDL0izKyKNcGJtKwVednYSk7lUhjpMHehlfPzVcQJ4lcQFfCd8BX0t8gveB8bjFxxxRFv3v8EigNpvl7uxdlqa5zJBaz0VxUuXxOgv8lhkQN/FESjCXg5iqDdEm8XS6UrwqbZmA1tZ5mcjPz0+FJSJyzKhb3g5sa8P06SryS+ymB4kvxOR8EpeCWqhFcQjDUEHAE5YUOOwTVJP0y6MYraA5xyUoSlKzdkyeQwWfDVRAfxu8jv3r4h0T+38epajSCQnhWrk2jROSRFI0JNyM2dW9cy+4u0rhdHRJWR+culrV7+d3wl+RXEV8KvIL+L+HazoNf2m2kpKnY20JmkxhQ43aoGlrV8eNBhu0qLnLmt+RM2JkfwHVt2hf4okqFUtIb87ZYafN98BfpdRPZiTdAaKmH6Q4RyFePbe/thKtyS5qZCrffzwKmgXuU/X0X9/ZBnu7dcnRARbZobA3VMWyMtlCh2NHOV2sWLDyV/Zps0GRTBafoqS+zH+uDpoWd46bgJUvDC/UFNoNoW+CmkJmZZTy7v8U23NlqF8J8My1K14HRy/y7i+1CvpF4rXub92w96NUVweYrV8m6qfSjaDkE+w4oVLzuXre21PgqPthI5NMxUv4rzdcgviDQzJYt8FcraWYBnEhXpKrb/iwjO7ZejrtYn52r4wLGHz7QgUsecoE7456/FidSqald/+6iMxHrGsru5+2yzIrZTS38nB/JZ+T2uuLEPHWZ7kkXRSJfALLPH/rJAeh6WvLk3mPD0SHI0UlodFM6dvmiHhAoRsucjDf7uE0x8SMgD9bcX9V3Os1VmWD3wkfNYdUPeXdloQOO2VLhpCejQlkXRaU/n8WDDUrbcwl7Nbtlj/grO64v43cwM0UPWgTPweBbR+bjCKOmQceRtVWvMinM1wTINDQNfXIkm82dogUdXuSXO3k3u/MnKWpD3kOzhMZVlXM81/uyErNqufBV4YjOIYZheGU2fJF0l+OLDRkXFXyL1+BmXvHnYYqXL0l5u0+c/GWFaGenxV2TA0sTPpCYvV5drdfCZT44rtfN4hmfaYY49Pgi1aK1+v57UAFq1tsWoreuN7JreKZX8sxk3NZ9dgVWWbbmdOmylUJjCX1K07Sa39MRqBpFw7J/jQYUgNQbB1ep5uYn4tMp7gBB+2IDp/nDx+LKBzPOM8L2HHd02WNDtEdXg/G93arMTJsL7B34MzyQkMT0baTZ8j0va1f1NgoJnTHo8J3AKmpcsuG61PuCQvdNftjmmRK6MzP2aLC8VRY97bqmItmCpFDWFKlayjk80XOCLETOzSw4wNKlCiLMd29xnySBKjNKen9z08bMIXy92A4StFMFtsJKJ/jhOa0QHjSCTAz85FtgQUhIKC7asJD037Kzo1sgdlWQsG8yzSyt/OopEo+bz4JpG7XBnU3miqSyLGw1ZsvfuQWRhfeaBHobZtta6otrpYc+OV2Tke8+nIq0hwuSLnV8eDwvD5WLDvLB2T8tKyqQV2Q3BmWTmIdpiZUz6c5FEe5xuWzV0MN3ezJBBb9rO6r6Gh6eaUsM5qAdRzt1H9Mkb8bTGkrqClHhGTLcjrJueYT7GDqLtsJBTcQj3DuGfnysQeBfJAKQpZkT2oBNMi3yGqaYbh/kskDHW5MLTXr3EdBLZzG+HhmRJO0bMW3sA1/RZgqTHPINoI3jsqKbCQgqAGj0bAQ90+RDdop9mHkfltI3ct9rM8MC14EeOl+BYNlr5eye2IXtZMsjEOOR6knpgnkZP8BbWAh4jbpPEE5DDKA1ce8NgS+DlABM0D9HBrPo0SmLMByaHUDK97bigWzw96BHTIgokH3wemLfodzvSuoke+nFFSe0wFa0u6fOeZ7Xz6l1cStAje7ATva2sdCfxNF0Jf+6SQjWT7h0m7al3W5Q8tSSp3NT0BHk82+8/B2aINvES4nwVtQ3X1SYJo/j7z8eG7KbfYz6hQO/Hnn6G/v24BPcwz9AjZppZvmUQBvUy0MWJIwFP01XeBRqXDW/EyKTmncx5eN4H8jHADeTZzmwNcMpGymOpqrehugSul/1NLx6omfaUd8ZI7d0/4JmVsEW/xwfHJXceg+QzDY/HYfOI3++H+XN4ZvGgZUx4nEJ6/kLKlpYfzfbOM6B0WYqDnofuco9eD/oz+TpePIkWOqLa8lOH83ciPUM8Tb9evNKNTcaSmV1G6Kd5euARkyLnKlK9y113fS7RDM+fvWSq6Wc2Gobpe/g1TA9PN/M4UqaHeBsz5rn3d5XXLk0cdr6esA8TdO/yUxlhiSQej7pyv3zU9OMDB6aiUU09ZalpYN7t34ut7zb79ObqXzq8GTHvJE6TV+/bIYbeQ7cZpg+4dLib54HpBz2yMVr0I/SeNdrNAZdYM9MfEnfmIxfvLl54hj99OZN2vGRwKRWa8ufj+UyNZ9vUyvGN8mXZLIOza6tSoGnm9gNtDPGaYaIKeFboPCxl1uY0QP+A4ODvN1s2B7392dlexCxxDyyTdvrmv392WFnq7trm3acJr5ZMzDY6xWuGRwlLZqI8UfZej6WzKRvgKai3wey96tC96chihvnIkpUsl8Rcbv/eNBAw7Qh5bJRn+gcUtxy7/DXPswbSA4/V557ZcvhwFVUt1h2Jn3U1jddaWqa1iH4ndRLdGT/wjDuq+iD5rsOlpzd9oJ7HSxn1gOqzgeKeY8vh7YsjgOZcyV2PBzLzk6/2MszjkVq3m7Z7ONpl7nKMWQJ0c9+7zcY6454uCI7rd4xrsORc/p10Lblpl6PeQ2RZy1cZIO+mZ6a5dzzBxPEaXCTE82lSFDhsNVYhtCCMmLLYSeAFKtwTzPQd9toAjBnmgpuW/Y0wsPYDI/T8tOE3/HHGm9/kRkDc5kRCFaugisSUU48+qy8h0WNjJILejdcMOiFzV13yMXuM2I3Y+EHgMLF57yr+umRbb6/YR9089XdGY4BW++ftqJxn25TZaiBjzAdnxtR5u7KPIYWp/nGHwDYHDo+5q2prMWJ37+MnLyObea9+L3bNpelcgSX7syw13FbUdpj5SQXwNqq1qtiFDFcd9+7xEVD6bpXIDDB6fzaeDegyz+v9rTpXqHEVytUPbPcjYSpbYmZLT7sdjnYJi+zVOb2fl6useqiSqAxCkWG9/VnVNRp91Jjl9ve/lctjYsurYzIqCT2eTAOQO8uznH7z223vrt890NPb6GgrzU8bbhVpB7+0/71g/OEB2pb6w8TGixNWn3a9pIZ4xKRXYtWxczifcCSyISrtCURGmwXGYt1HAdONfCN4uXusHvpyAFaJ2I6V99UW3eIG48HrDlk1261ez2+oh8ZpnrWLk/5d6VaB1eONuLaUamDKXL3tUbfHPwuOXEU3vIQQbZ3PC8tWX7qcTlTSe6R95eTup9ub49yfIxhzCmkwgixyfTj8rt7davKRzbZsXsKjzbeJ/f/NVWKSZGQtzCSC5Mjlz5vjVnxSuXM2t65oiPH8PZdPA97W2ndyUu2oca3wutpY1LgLy+6knbcRYxqdgncQPKi3ybpviYRH5AoDWqA1dlhXuBHAGB8U7iQjvI+oCzOO3MkPD7CwwIoY3NKcO4K9euDnIsaBQPRdXb+rtLbTvgRl7vk88VF0Q0HHBbHwwbUkaZpJfTDDL25t2lz9bBXjO3eJFVtNbG6rK3rSUlnMR82KPdysEbhLUo7A3BqtHZHxV4nNoTtaILMh8nL7ldWdHmvAFWvVm057nVgpyyC3+aifymL5zdERsYxTbqZaUBtyyp+R2wVUtDvAsRJ6/KC/8dWfyztpum2491S52bkvLpkb+D2ijRD5xlfRmBsstQAjCykRaZU4LYjsurW9sRXToKtVev07FN4BiFwgNlCZtVzoWDCWaXRzD7idjtwX/IzanDrsYe97RIbbqwqvAqNrsQgjsffbyfSNSVaB3YcJmbC0ds/HBCk0+1aZn3qWJ+RGhtbS2qmQ8PaWaqXxmJ99XvyZ3pZ9pj0blLW90KeoMs/iwCfc9m3Bmb84YrlOxEfvOCYbZlOFtpZb7dWWKKvSe9ENVXa1blbJ9YPtC28DylzGY6t//nnlaXxt2KHLo1sQ7sdcxMblNZYnWGmOdYArxv9Xvm+lgB29xdLgxZxlpJlOk+Mc3dKVK4wsZ3c+m7Y6Ely4W37HQ2Pyow3hC5pwr4OxQxjF1bsfxGcBAtm4yqWzue+P3HvcoNW26+IDiJcnzz2wNjzlkcxnmMNWD1tq92LTuoWfIfYFxN0UudMkPhSa6aUVmUhmeFxau2EUq32149eexUsJYNDqHXq0Yfvz7uHl6bFveAzyyxafTHCpHpkjx059tRXsRhoSd+VfHwNdVuLB73D3BG8ztFMdhS0fbY/03AhYb4WBjm0kPq/c7kP6Rk722JwftavM9t/OWO+xxmqL8ogIIj5iZXxY6HzyV/vCVKw1b1p4C3U+SL6QZ9Tfkpw4Te9Emn2hKIMNv1vTub/ckrFE5XaCN2y5/Us7T1nQCl0vzOf94rieGN/0ziJmVaYfSvhDpmJfemzK0YGHL7n4MSvdw/ykmxN/I+Y6jk9FMT5eA9x9CNuW+pSrDZW1ZJCWwDbFagptZzU4T3pzMzcfnTImUmZ888nXm/OrICzqmYPM7Ntjl++jT4n0nvFP3uvODy7i68JCbcnLjcX77uPVJn/Sw71Keh9wnLAbCXfsvCPn1C0iuFXx74pcQfWyQB9m7c4Pw7C6Yzo/n1kAn09Y4NiB0P2xI2zSlXqrhcHLswwz0P0v72t2W56vE9N0MtfzEdtIbTX4d6sA32htQHqkAAAAAElFTkSuQmCC" />
   <link rel="stylesheet" href="./assets/css/styles.css" />
 </head>
-
 <body>
-<header class="navbar" id="navbar">
-  <div class="container nav-inner">
-    <a class="brand" href="./"><img class="brand-logo" src="./assets/img/logo.png" alt="Retro Web" /><span class="brand-text">Retro Web</span></a>
-    <button class="hamburger" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
-      <span></span><span></span><span></span>
-    </button>
-    <nav class="nav-desktop">
+  <!-- Barra de navegación reutilizable -->
+  <header class="barra" id="navbar">
+    <div class="contenedor barra__contenido">
+      <a class="marca" href="./">
+        <img class="marca__logo" src="./assets/img/logo.png" alt="Retro Web" />
+        <span class="marca__texto">Retro Web</span>
+      </a>
+      <button class="menu" id="hamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileMenu">
+        <span></span><span></span><span></span>
+      </button>
+      <nav class="enlaces">
+        <a href="./">Inicio</a>
+        <a href="./sobre.html">Sobre mí</a>
+        <a href="./portafolio.html">Portafolio</a>
+        <a href="./contacto.html">Contacto</a>
+      </nav>
+    </div>
+    <nav class="enlaces enlaces--movil" id="mobileMenu" hidden>
       <a href="./">Inicio</a>
       <a href="./sobre.html">Sobre mí</a>
       <a href="./portafolio.html">Portafolio</a>
       <a href="./contacto.html">Contacto</a>
     </nav>
-  </div>
-  <nav class="nav-mobile" id="mobileMenu" hidden>
-    <a href="./">Inicio</a>
-    <a href="./sobre.html">Sobre mí</a>
-    <a href="./portafolio.html">Portafolio</a>
-    <a href="./contacto.html">Contacto</a>
-  </nav>
-</header>
+  </header>
 
-<main class="container page">
-  <h1>Sobre mí</h1>
-  <p class="lead">Hola terrícula! Soy Alberto, artista digital inspirado en la estética retro y en los videojuegos de 8 bits. Este es mi aportación creativa para mostrar ilustraciones y proyectos con alma arcade. Bienvenido!</p>
+  <!-- Presentación personal -->
+  <main class="contenedor pagina">
+    <h1>Sobre mí</h1>
+    <p class="lead">Soy Alberto, artista digital enamorado de los arcades clásicos y de su estética luminosa.</p>
+    <section class="tarjetas tarjetas--dobles">
+      <article>
+        <h2>Filosofía</h2>
+        <p>La nostalgia puede ser innovadora: mezclo recuerdos de recreativas con técnicas actuales.</p>
+      </article>
+      <article>
+        <h2>Tecnologías</h2>
+        <p>Trabajo con p5.js, HTML, CSS y JavaScript; también experimento con shaders y audio chiptune.</p>
+      </article>
+    </section>
+  </main>
 
-  <div class="about-grid">
-    <div>
-      <h2>Filosofía</h2>
-      <p>La nostalgia puede ser innovadora: recreo sensaciones clásicas con técnicas modernas.</p>
+  <!-- Pie de página con redes -->
+  <footer class="pie">
+    <div class="contenedor pie__contenido">
+      <p>© <span id="year"></span> Retro Web. Vibes arcade.</p>
+      <div class="pie__redes">
+        <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
+      </div>
     </div>
-    <div>
-      <h2>Tecnologías</h2>
-      <p>p5.js, HTML, CSS, JavaScript. A veces toques de shaders o audio chiptune.</p>
-    </div>
-  </div>
-</main>
-<footer class="footer">
-  <div class="container footer-inner">
-    <p>© <span id="year"></span> Retro Web · Hecho por Alberto con vibes arcade de los 80.</p>
-    <div class="socials">
-      <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a>
-    </div>
-  </div>
-</footer>
-<script src="./assets/js/script.js"></script>
+  </footer>
+  <script src="./assets/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Simplified every HTML page with concise structure and added comentarios en español for each bloque.
- Rewrote the shared CSS with sectioned Spanish comments and a lighter rule set for the retro look.
- Refined the JavaScript, keeping only the required behaviours and documenting cada bloque en español.

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e12b4786f4832bb9f10070945f9742