### PR TITLE
Refine retro layout and styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -22,6 +22,7 @@ body {
   background: var(--fondo);
   color: var(--texto);
   line-height: 1.6;
+  font-family: "Press Start 2P", system-ui, sans-serif;
 }
 
 a {
@@ -132,6 +133,11 @@ a {
   opacity: 0.9;
 }
 
+.hero__texto,
+.hero .boton {
+  max-width: 520px;
+}
+
 .hero__figura {
   display: grid;
   gap: 8px;
@@ -158,6 +164,9 @@ a {
   border: 2px solid #000;
   box-shadow: 4px 4px 0 #000;
   text-decoration: none;
+  font-family: inherit;
+  letter-spacing: 1px;
+  text-transform: uppercase;
 }
 
 .boton:hover {
@@ -177,20 +186,98 @@ a {
   to { text-shadow: 0 0 16px var(--verde); }
 }
 
-/* Marco estilo CRT */
-.crt {
+/* Televisor retro para la animación principal */
+.tele {
   position: relative;
-  border: 2px solid var(--borde);
-  padding: 8px;
+  width: min(100%, 420px);
+  padding: 48px 32px 80px;
+  border-radius: 28px 28px 20px 20px;
+  background: linear-gradient(145deg, #2b2b2b, #121212 60%, #050505 100%);
+  box-shadow: 0 24px 40px rgba(0, 0, 0, 0.65), inset 0 0 0 2px rgba(255, 255, 255, 0.05);
 }
 
-.crt::after {
+.tele::before,
+.tele::after {
   content: "";
   position: absolute;
-  inset: 0;
+  width: 4px;
+  height: 70px;
+  top: -70px;
+  background: linear-gradient(#333, #999);
+  border-radius: 999px;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+}
+
+.tele::before {
+  left: 28%;
+  transform: rotate(-10deg);
+}
+
+.tele::after {
+  right: 28%;
+  transform: rotate(12deg);
+}
+
+.tele__pantalla {
+  position: relative;
+  border-radius: 18px;
+  padding: 12px;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0.95) 65%);
+  box-shadow: inset 0 0 0 3px #050505, inset 0 0 0 6px rgba(0, 0, 0, 0.85);
+}
+
+.tele__pantalla::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
   pointer-events: none;
-  background: linear-gradient(transparent 50%, rgba(255, 255, 255, 0.04) 50%);
-  background-size: 100% 4px;
+  border-radius: 12px;
+  background: linear-gradient(transparent 50%, rgba(255, 255, 255, 0.05) 50%);
+  background-size: 100% 6px;
+  mix-blend-mode: screen;
+  opacity: 0.7;
+}
+
+.tele__panel {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 16px;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.tele__panel span {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #323232;
+  box-shadow: inset -1px -1px 0 rgba(255, 255, 255, 0.2), inset 1px 1px 0 rgba(0, 0, 0, 0.6);
+}
+
+.tele__panel span:nth-child(1) {
+  background: radial-gradient(circle at 30% 30%, #ffb347, #cc5500 70%);
+}
+
+.tele__panel span:nth-child(2) {
+  background: radial-gradient(circle at 30% 30%, #8be4ff, #006c99 70%);
+}
+
+.tele__panel span:nth-child(3) {
+  background: radial-gradient(circle at 30% 30%, #ff9ffd, #7300a0 70%);
+}
+
+.crt {
+  position: relative;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.crt canvas {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 /* Listados de tarjetas */
@@ -214,17 +301,47 @@ a {
 
 .rejilla {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  justify-content: center;
+  justify-items: center;
 }
 
 .tarjetas li,
 .tarjetas--dobles article,
 .rejilla article {
   border: 1px solid var(--borde);
-  padding: 16px;
-  background: rgba(255, 255, 255, 0.02);
+  padding: 20px 18px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
+  text-align: center;
+  width: 100%;
+  max-width: 300px;
+}
+
+.rejilla h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  color: var(--amarillo);
+  text-shadow: 0 0 6px rgba(255, 255, 0, 0.4);
+}
+
+.rejilla p {
+  margin: 0 0 18px;
+}
+
+.rejilla .boton {
+  font-size: 0.65rem;
 }
 
 /* Estilos específicos de página */
+.pagina {
+  display: grid;
+  gap: 24px;
+  justify-items: center;
+  text-align: center;
+}
+
 .pagina h1 {
   margin-top: 24px;
 }
@@ -232,6 +349,7 @@ a {
 .lead {
   opacity: 0.95;
   margin-bottom: 18px;
+  max-width: 620px;
 }
 
 /* Formulario de contacto */
@@ -239,6 +357,13 @@ a {
   display: grid;
   gap: 12px;
   max-width: 520px;
+  margin: 0 auto;
+}
+
+.formulario label {
+  display: grid;
+  gap: 8px;
+  text-align: left;
 }
 
 .formulario input,
@@ -248,6 +373,7 @@ a {
   border: 2px solid #000;
   background: #0a0a0a;
   color: var(--texto);
+  font-family: inherit;
 }
 
 .formulario input:focus,
@@ -255,6 +381,10 @@ a {
   outline: none;
   border-color: var(--magenta);
   box-shadow: 0 0 8px var(--magenta);
+}
+
+.formulario .boton {
+  justify-self: center;
 }
 
 .nota {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -33,11 +33,11 @@ if (botonMenu && menuMovil) {
   const canvas = document.getElementById('heroCanvas');
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
-  const proporcion = 16 / 9;
+  const proporcion = 4 / 3;
 
   // Ajusta el tamaño del canvas según el ancho disponible
   const redimensionar = () => {
-    const ancho = Math.min(canvas.parentElement?.clientWidth || 640, 640);
+    const ancho = Math.min(canvas.parentElement?.clientWidth || 520, 520);
     const alto = Math.round(ancho / proporcion);
     canvas.width = ancho;
     canvas.height = alto;

--- a/index.html
+++ b/index.html
@@ -49,8 +49,13 @@
         <img src="./assets/img/marcianito.svg" alt="Marcianito 8-bit" />
         <figcaption>Nuestro guardián pixelado vigila la galaxia.</figcaption>
       </figure>
-      <div class="crt">
-        <canvas id="heroCanvas" aria-label="Animación retro"></canvas>
+      <div class="tele" aria-label="Televisor retro">
+        <div class="tele__pantalla crt">
+          <canvas id="heroCanvas" aria-label="Animación retro"></canvas>
+        </div>
+        <div class="tele__panel" aria-hidden="true">
+          <span></span><span></span><span></span>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Wrap the hero canvas in an 80s-inspired television frame with antenna details and chrome controls.
- Refresh the global retro look by centering portfolio content, tightening typography, and applying the pixel font to buttons and form elements.
- Adjust the hero animation to a 4:3 aspect ratio so it fits the new television casing.

## Testing
- No automated tests were run (not applicable).


------
https://chatgpt.com/codex/tasks/task_e_68e1335b326c832bb56ca749cd4942d3