### PR TITLE
Restore interactive p5 portfolio

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -161,6 +161,19 @@ a {
   box-shadow: 6px 6px 0 #000;
 }
 
+.boton--secundario {
+  background: transparent;
+  color: var(--texto);
+  border-color: var(--texto);
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.6);
+}
+
+.boton--secundario:hover {
+  color: var(--amarillo);
+  border-color: var(--amarillo);
+  box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.8);
+}
+
 @media (min-width: 900px) {
   .hero {
     grid-template-columns: minmax(0, 1fr) minmax(0, 420px);
@@ -373,6 +386,10 @@ a {
   text-align: center;
 }
 
+.pagina--portafolio {
+  gap: 32px;
+}
+
 .pagina h1 {
   margin-top: 24px;
 }
@@ -381,6 +398,177 @@ a {
   opacity: 0.95;
   margin-bottom: 18px;
   max-width: 620px;
+}
+
+.portafolio__encabezado {
+  display: grid;
+  gap: 16px;
+  justify-items: center;
+}
+
+.portafolio__area {
+  display: grid;
+  gap: 28px;
+  width: 100%;
+}
+
+.portafolio__visor {
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+  text-align: center;
+}
+
+.portafolio__titulo {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--verde);
+  text-shadow: 0 0 10px rgba(0, 255, 0, 0.5);
+}
+
+.portafolio__descripcion {
+  margin: 0;
+  font-size: 0.75rem;
+  max-width: 560px;
+  opacity: 0.85;
+}
+
+.portafolio__pantalla {
+  position: relative;
+  width: min(100%, 720px);
+  aspect-ratio: 4 / 3;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 0, 255, 0.1), rgba(0, 0, 0, 0.9));
+  border: 1px solid var(--borde);
+  border-radius: 18px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+.portafolio__pantalla::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+      to bottom,
+      rgba(0, 255, 0, 0.08),
+      rgba(0, 255, 0, 0.08) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+  pointer-events: none;
+  opacity: 0.15;
+}
+
+.portafolio__pantalla iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #000;
+}
+
+.portafolio__lista-contenedor {
+  width: 100%;
+}
+
+.portafolio__lista {
+  display: grid;
+  gap: 18px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.portafolio__item {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid var(--borde);
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 14px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.45);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.portafolio__item:hover {
+  transform: translateY(-4px);
+}
+
+.portafolio__item.activo {
+  border-color: var(--verde);
+  background: rgba(0, 255, 0, 0.05);
+  box-shadow: 0 12px 28px rgba(0, 255, 0, 0.18);
+}
+
+.portafolio__selector {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  display: grid;
+  gap: 8px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.portafolio__selector:focus-visible {
+  outline: 2px solid var(--amarillo);
+  outline-offset: 4px;
+}
+
+.portafolio__nombre {
+  font-size: 0.78rem;
+  color: var(--amarillo);
+  text-shadow: 0 0 6px rgba(255, 255, 0, 0.4);
+}
+
+.portafolio__resumen {
+  font-size: 0.7rem;
+  margin: 0;
+  opacity: 0.85;
+  line-height: 1.5;
+}
+
+.portafolio__etiquetas {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--magenta);
+}
+
+.portafolio__item .boton {
+  justify-self: start;
+  font-size: 0.6rem;
+  padding: 10px 14px;
+}
+
+@media (min-width: 880px) {
+  .portafolio__area {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .portafolio__lista {
+    max-height: 620px;
+    overflow-y: auto;
+    padding-right: 8px;
+  }
+}
+
+@media (max-width: 640px) {
+  .portafolio__pantalla {
+    border-radius: 14px;
+  }
+
+  .portafolio__titulo {
+    font-size: 0.85rem;
+  }
+
+  .portafolio__resumen {
+    font-size: 0.68rem;
+  }
 }
 
 /* Formulario de contacto */

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -72,3 +72,44 @@ if (botonMenu && menuMovil) {
 
   dibujar();
 })();
+
+// --- Visor interactivo para la página de portafolio ---
+(() => {
+  const visor = document.querySelector('[data-portafolio-visor]');
+  const items = document.querySelectorAll('[data-portafolio-item]');
+  if (!visor || !items.length) return;
+
+  const iframe = visor.querySelector('iframe');
+  const titulo = document.getElementById('portafolioPreviewTitle');
+  const descripcion = document.getElementById('portafolioPreviewDescripcion');
+
+  const activar = (item) => {
+    items.forEach((elemento) => elemento.classList.toggle('activo', elemento === item));
+    const { src, title, description } = item.dataset;
+
+    if (iframe && src && iframe.getAttribute('src') !== src) {
+      iframe.setAttribute('src', src);
+    }
+
+    if (iframe && title) {
+      iframe.setAttribute('title', `Demo p5.js: ${title}`);
+    }
+
+    if (titulo && title) {
+      titulo.textContent = title;
+    }
+
+    if (descripcion) {
+      descripcion.textContent = description || '';
+    }
+  };
+
+  items.forEach((item) => {
+    const boton = item.querySelector('button');
+    if (!boton) return;
+
+    boton.addEventListener('click', () => activar(item));
+  });
+
+  activar(items[0]);
+})();

--- a/portafolio.html
+++ b/portafolio.html
@@ -32,41 +32,162 @@
     </nav>
   </header>
 
-  <!-- Listado de proyectos destacados -->
-  <main class="contenedor pagina">
-    <h1>Portafolio</h1>
-    <p class="lead">Seis mini proyectos p5.js inspirados en recreativas míticas de los 80.</p>
-    <section class="rejilla">
-      <article>
-        <h3>Space Invaders Recharged</h3>
-        <p>Marcianitos con ritmo ochentañero y brillo neón.</p>
-        <a class="boton" href="./proyectos/space-invaders/">Abrir demo</a>
-      </article>
-      <article>
-        <h3>Pac-Man Remix</h3>
-        <p>El laberinto clásico al compás del synthwave.</p>
-        <a class="boton" href="./proyectos/pacman/">Abrir demo</a>
-      </article>
-      <article>
-        <h3>Donkey Kong Rampage</h3>
-        <p>Aventuras de barriles con alma de recreativa.</p>
-        <a class="boton" href="./proyectos/donkey-kong/">Abrir demo</a>
-      </article>
-      <article>
-        <h3>Galaga Reloaded</h3>
-        <p>Defiende la galaxia entre luces fosforitas.</p>
-        <a class="boton" href="./proyectos/galaga/">Abrir demo</a>
-      </article>
-      <article>
-        <h3>Ghosts’n Goblins Revival</h3>
-        <p>Sir Arthur vuelve a por demonios imposibles.</p>
-        <a class="boton" href="./proyectos/ghosts-goblins/">Abrir demo</a>
-      </article>
-      <article>
-        <h3>Out Run Neo80</h3>
-        <p>Ferrari rojo, palmeras y puestas de sol retro.</p>
-        <a class="boton" href="./proyectos/outrun/">Abrir demo</a>
-      </article>
+  <!-- Portafolio interactivo con visor centrado -->
+  <main class="contenedor pagina pagina--portafolio">
+    <header class="portafolio__encabezado">
+      <h1 id="portafolioTitulo">Portafolio p5.js</h1>
+      <p class="lead">
+        Descubre seis mini demos inspiradas en los salones arcade de los 80. Selecciona un proyecto
+        para verlo en el visor central y lánzate a jugar en pantalla completa cuando quieras.
+      </p>
+    </header>
+
+    <section class="portafolio__area" aria-labelledby="portafolioTitulo">
+      <div class="portafolio__visor" data-portafolio-visor>
+        <h2 id="portafolioPreviewTitle" class="portafolio__titulo">Space Invaders Recharged</h2>
+        <p id="portafolioPreviewDescripcion" class="portafolio__descripcion">
+          Marcianitos con ritmo ochentañero y brillo neón.
+        </p>
+        <div class="portafolio__pantalla">
+          <iframe
+            src="./proyectos/space-invaders/index.html"
+            title="Demo p5.js: Space Invaders Recharged"
+            loading="lazy"
+            allowfullscreen
+          ></iframe>
+        </div>
+      </div>
+
+      <div class="portafolio__lista-contenedor">
+        <ul class="portafolio__lista" role="list">
+          <li
+            class="portafolio__item activo"
+            data-portafolio-item
+            data-src="./proyectos/space-invaders/index.html"
+            data-title="Space Invaders Recharged"
+            data-description="Marcianitos con ritmo ochentañero y brillo neón."
+          >
+            <button type="button" class="portafolio__selector">
+              <span class="portafolio__nombre">Space Invaders Recharged</span>
+              <span class="portafolio__resumen">Marcianitos con ritmo ochentañero y brillo neón.</span>
+              <span class="portafolio__etiquetas">Shoot’em up · Flujo neón</span>
+            </button>
+            <a
+              class="boton boton--secundario"
+              href="./proyectos/space-invaders/"
+              target="_blank"
+              rel="noopener"
+            >
+              Abrir demo completa
+            </a>
+          </li>
+          <li
+            class="portafolio__item"
+            data-portafolio-item
+            data-src="./proyectos/pacman/index.html"
+            data-title="Pac-Man Remix"
+            data-description="El laberinto clásico al compás del synthwave."
+          >
+            <button type="button" class="portafolio__selector">
+              <span class="portafolio__nombre">Pac-Man Remix</span>
+              <span class="portafolio__resumen">El laberinto clásico al compás del synthwave.</span>
+              <span class="portafolio__etiquetas">Maze · Synthwave</span>
+            </button>
+            <a
+              class="boton boton--secundario"
+              href="./proyectos/pacman/"
+              target="_blank"
+              rel="noopener"
+            >
+              Abrir demo completa
+            </a>
+          </li>
+          <li
+            class="portafolio__item"
+            data-portafolio-item
+            data-src="./proyectos/donkey-kong/index.html"
+            data-title="Donkey Kong Rampage"
+            data-description="Aventuras de barriles con alma de recreativa."
+          >
+            <button type="button" class="portafolio__selector">
+              <span class="portafolio__nombre">Donkey Kong Rampage</span>
+              <span class="portafolio__resumen">Aventuras de barriles con alma de recreativa.</span>
+              <span class="portafolio__etiquetas">Plataformas · 8 bits</span>
+            </button>
+            <a
+              class="boton boton--secundario"
+              href="./proyectos/donkey-kong/"
+              target="_blank"
+              rel="noopener"
+            >
+              Abrir demo completa
+            </a>
+          </li>
+          <li
+            class="portafolio__item"
+            data-portafolio-item
+            data-src="./proyectos/galaga/index.html"
+            data-title="Galaga Reloaded"
+            data-description="Defiende la galaxia entre luces fosforitas."
+          >
+            <button type="button" class="portafolio__selector">
+              <span class="portafolio__nombre">Galaga Reloaded</span>
+              <span class="portafolio__resumen">Defiende la galaxia entre luces fosforitas.</span>
+              <span class="portafolio__etiquetas">Arcade espacial · Ritmo rápido</span>
+            </button>
+            <a
+              class="boton boton--secundario"
+              href="./proyectos/galaga/"
+              target="_blank"
+              rel="noopener"
+            >
+              Abrir demo completa
+            </a>
+          </li>
+          <li
+            class="portafolio__item"
+            data-portafolio-item
+            data-src="./proyectos/ghosts-goblins/index.html"
+            data-title="Ghosts’n Goblins Revival"
+            data-description="Sir Arthur vuelve a por demonios imposibles."
+          >
+            <button type="button" class="portafolio__selector">
+              <span class="portafolio__nombre">Ghosts’n Goblins Revival</span>
+              <span class="portafolio__resumen">Sir Arthur vuelve a por demonios imposibles.</span>
+              <span class="portafolio__etiquetas">Acción · Dificultad retro</span>
+            </button>
+            <a
+              class="boton boton--secundario"
+              href="./proyectos/ghosts-goblins/"
+              target="_blank"
+              rel="noopener"
+            >
+              Abrir demo completa
+            </a>
+          </li>
+          <li
+            class="portafolio__item"
+            data-portafolio-item
+            data-src="./proyectos/outrun/index.html"
+            data-title="Out Run Neo80"
+            data-description="Ferrari rojo, palmeras y puestas de sol retro."
+          >
+            <button type="button" class="portafolio__selector">
+              <span class="portafolio__nombre">Out Run Neo80</span>
+              <span class="portafolio__resumen">Ferrari rojo, palmeras y puestas de sol retro.</span>
+              <span class="portafolio__etiquetas">Carreras · Sunset vibes</span>
+            </button>
+            <a
+              class="boton boton--secundario"
+              href="./proyectos/outrun/"
+              target="_blank"
+              rel="noopener"
+            >
+              Abrir demo completa
+            </a>
+          </li>
+        </ul>
+      </div>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- rebuild the portfolio page with a centered p5.js viewer and project list
- add responsive styles and secondary button treatment for the new layout
- extend the main script to switch the embedded demo and copy when a project is selected

## Testing
- no automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e13894bd04832b9c293369152c91a0