### PR TITLE
Simplify navigation container structure

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -48,6 +48,9 @@ a {
 
 /* Distribución interna de la barra */
 .barra__contenido {
+  width: min(100%, 1040px);
+  margin: 0 auto;
+  padding: 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/contacto.html
+++ b/contacto.html
@@ -10,7 +10,7 @@
 <body>
   <!-- Barra de navegación reutilizable -->
   <header class="barra" id="navbar">
-    <div class="contenedor barra__contenido">
+    <div class="barra__contenido">
       <a class="marca" href="./">
         <span class="marca__texto">Retro Web</span>
       </a>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
   <!-- Barra de navegación reutilizable -->
   <header class="barra" id="navbar">
-    <div class="contenedor barra__contenido">
+    <div class="barra__contenido">
       <a class="marca" href="./">
         <span class="marca__texto">Retro Web</span>
       </a>

--- a/portafolio.html
+++ b/portafolio.html
@@ -10,7 +10,7 @@
 <body>
   <!-- Barra de navegación reutilizable -->
   <header class="barra" id="navbar">
-    <div class="contenedor barra__contenido">
+    <div class="barra__contenido">
       <a class="marca" href="./">
         <span class="marca__texto">Retro Web</span>
       </a>

--- a/proyectos/donkey-kong/index.html
+++ b/proyectos/donkey-kong/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <header class="barra" id="navbar">
-  <div class="contenedor barra__contenido">
+  <div class="barra__contenido">
     <a class="marca" href="../../index.html">
       <span class="marca__texto">Retro Web</span>
     </a>

--- a/proyectos/galaga/index.html
+++ b/proyectos/galaga/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <header class="barra" id="navbar">
-  <div class="contenedor barra__contenido">
+  <div class="barra__contenido">
     <a class="marca" href="../../index.html">
       <span class="marca__texto">Retro Web</span>
     </a>

--- a/proyectos/ghosts-goblins/index.html
+++ b/proyectos/ghosts-goblins/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <header class="barra" id="navbar">
-  <div class="contenedor barra__contenido">
+  <div class="barra__contenido">
     <a class="marca" href="../../index.html">
       <span class="marca__texto">Retro Web</span>
     </a>

--- a/proyectos/outrun/index.html
+++ b/proyectos/outrun/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <header class="barra" id="navbar">
-  <div class="contenedor barra__contenido">
+  <div class="barra__contenido">
     <a class="marca" href="../../index.html">
       <span class="marca__texto">Retro Web</span>
     </a>

--- a/proyectos/pacman/index.html
+++ b/proyectos/pacman/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <header class="barra" id="navbar">
-  <div class="contenedor barra__contenido">
+  <div class="barra__contenido">
     <a class="marca" href="../../index.html">
       <span class="marca__texto">Retro Web</span>
     </a>

--- a/proyectos/space-invaders/index.html
+++ b/proyectos/space-invaders/index.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <header class="barra" id="navbar">
-  <div class="contenedor barra__contenido">
+  <div class="barra__contenido">
     <a class="marca" href="../../index.html">
       <span class="marca__texto">Retro Web</span>
     </a>

--- a/sobre.html
+++ b/sobre.html
@@ -10,7 +10,7 @@
 <body>
   <!-- Barra de navegación reutilizable -->
   <header class="barra" id="navbar">
-    <div class="contenedor barra__contenido">
+    <div class="barra__contenido">
       <a class="marca" href="./">
         <span class="marca__texto">Retro Web</span>
       </a>


### PR DESCRIPTION
## Summary
- remove the redundant contenedor class wrapper from each navigation bar
- move the width, margin, and padding rules to .barra__contenido to preserve layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e142e24174832b8de7d9d0c3f3a065